### PR TITLE
fixes hls generation for docker builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 media_files/encoded/
 media_files/original/
+media_files/hls/
 postgres_data/
 celerybeat-schedule
 logs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ COPY . /home/mediacms.io/mediacms
 WORKDIR /home/mediacms.io/mediacms
 
 RUN wget -q http://zebulon.bok.net/Bento4/binaries/Bento4-SDK-1-6-0-632.x86_64-unknown-linux.zip && \
-    mkdir -p /home/mediacms.io/mediacms/media_files/hls Bento4-SDK-1-6-0-632.x86_64-unknown-linux/bin/ && \
-    unzip -j Bento4-SDK-1-6-0-632.x86_64-unknown-linux.zip Bento4-SDK-1-6-0-632.x86_64-unknown-linux/bin/mp4hls -d Bento4-SDK-1-6-0-632.x86_64-unknown-linux/bin/ && \
+    unzip Bento4-SDK-1-6-0-632.x86_64-unknown-linux.zip -d ../bento4 && \
+    mv ../bento4/Bento4-SDK-1-6-0-632.x86_64-unknown-linux/* ../bento4/ && \
+    rm -rf ../bento4/Bento4-SDK-1-6-0-632.x86_64-unknown-linux && \
+    rm -rf ../bento4/docs && \
     rm Bento4-SDK-1-6-0-632.x86_64-unknown-linux.zip
 
 ############ RUNTIME IMAGE ############

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -6,7 +6,7 @@ ln -sf /dev/stdout /var/log/nginx/access.log && ln -sf /dev/stderr /var/log/ngin
 ln -sf /dev/stdout /var/log/nginx/mediacms.io.access.log && ln -sf /dev/stderr /var/log/nginx/mediacms.io.error.log
 cp /home/mediacms.io/mediacms/deploy/docker/local_settings.py /home/mediacms.io/mediacms/cms/local_settings.py
 
-mkdir -p /home/mediacms.io/mediacms/{logs,pids}
+mkdir -p /home/mediacms.io/mediacms/{logs,pids,media_files/hls}
 touch /home/mediacms.io/mediacms/logs/debug.log
 
 chown -R www-data. /home/mediacms.io/

--- a/deploy/docker/local_settings.py
+++ b/deploy/docker/local_settings.py
@@ -29,4 +29,8 @@ CACHES = {
 BROKER_URL = REDIS_LOCATION
 CELERY_RESULT_BACKEND = BROKER_URL
 
+MP4HLS_COMMAND = (
+    "/home/mediacms.io/bento4/bin/mp4hls"
+)
+
 DEBUG = False


### PR DESCRIPTION
* Had trimmed out too much from the bento-sdk
* placed the bento a level below the source, so it is not mounted over by the source folder