### PR TITLE
allow media of all states to be added to playlist

### DIFF
--- a/files/models.py
+++ b/files/models.py
@@ -1386,7 +1386,7 @@ class Playlist(models.Model):
     @property
     def thumbnail_url(self):
         pm = self.playlistmedia_set.first()
-        if pm:
+        if pm and pm.media.thumbnail:
             return helpers.url_from_path(pm.media.thumbnail.path)
         return None
 

--- a/files/views.py
+++ b/files/views.py
@@ -896,7 +896,7 @@ class PlaylistDetail(APIView):
 
         if action in ["add", "remove", "ordering"]:
             media = Media.objects.filter(
-                friendly_token=media_friendly_token, state="public"
+                friendly_token=media_friendly_token
             ).first()
             if media:
                 if action == "add":


### PR DESCRIPTION
1. allow an unlisted media to be added to a playlist (not only public media)
2. allow playlists with audio only to function - fixes https://github.com/mediacms-io/mediacms/issues/153