### PR TITLE
Add default local settings file

### DIFF
--- a/cms/default_local_settings.py
+++ b/cms/default_local_settings.py
@@ -1,0 +1,27 @@
+# This is a template for your local settingsfile.
+# Copy this file to local_settings.py and you're able to override
+# every setting from settings.py for your local setup.
+
+DEBUG = False
+
+# email settings
+DEFAULT_FROM_EMAIL = "info@mediacms.io"
+EMAIL_HOST_PASSWORD = "xyz"
+EMAIL_HOST_USER = "info@mediacms.io"
+EMAIL_USE_TLS = True
+SERVER_EMAIL = DEFAULT_FROM_EMAIL
+EMAIL_HOST = "mediacms.io"
+EMAIL_PORT = 587
+ADMIN_EMAIL_LIST = ["info@mediacms.io"]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "mediacms",
+        "HOST": "127.0.0.1",
+        "PORT": "5432",
+        "USER": "mediacms",
+        "PASSWORD": "mediacms",
+    }
+}
+

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -2,11 +2,11 @@
 
 A number of options are available on `cms/settings.py`. 
 
-It is advisable to override any of them by adding it to `local_settings.py` . 
+It is advisable not to modify that file directly but to override the values by adding them to `local_settings.py` . 
 
-In case of a the single server installation, add to `cms/local_settings.py` .
+In case of a the single server installation, copy `cms/default_local_settings.py` to `cms/local_settings.py` .
 
-In case of a docker compose installation, add to `deploy/docker/local_settings.py` . This will automatically overwrite `cms/local_settings.py` .
+In case of a docker compose installation, copy `cms/default_local_settings.py` to `deploy/docker/local_settings.py`. This will automatically overwrite `cms/local_settings.py` .
 
 Any change needs restart of MediaCMS in order to take effect. So edit `cms/local_settings.py`, make a change and restart MediaCMS 
 


### PR DESCRIPTION
Create a default_local_settings.py as a template for local_settings.py.
We should support all beginners with a good workflow to keep their credentials save.