### PR TITLE
Feat login required

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -427,6 +427,10 @@ CELERY_BEAT_SCHEDULE = {
 
 LOCAL_INSTALL = False
 
+# this is an option to make the whole portal available to logged in users only
+# it is placed here so it can be overrided on local_settings.py
+GLOBAL_LOGIN_REQUIRED = False
+
 try:
     # keep a local_settings.py file for local overrides
     from .local_settings import *
@@ -447,6 +451,11 @@ if LOCAL_INSTALL:
 else:
     SSL_FRONTEND_HOST = FRONTEND_HOST
 
-GLOBAL_LOGIN_REQUIRED = False
 if GLOBAL_LOGIN_REQUIRED:
+    # this should go after the AuthenticationMiddleware middleware
     MIDDLEWARE.insert(5, "login_required.middleware.LoginRequiredMiddleware")
+    LOGIN_REQUIRED_IGNORE_PATHS = [
+        r'/accounts/login/$',
+        r'/accounts/logout/$',
+        r'/accounts/signup/$',
+    ]

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -446,3 +446,7 @@ if LOCAL_INSTALL:
     SSL_FRONTEND_HOST = FRONTEND_HOST.replace("http", "https")
 else:
     SSL_FRONTEND_HOST = FRONTEND_HOST
+
+GLOBAL_LOGIN_REQUIRED = False
+if GLOBAL_LOGIN_REQUIRED:
+    MIDDLEWARE.insert(5, "login_required.middleware.LoginRequiredMiddleware")

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,11 +29,14 @@ m3u8
 
 django-ckeditor
 
+django-login-required-middleware==0.6.1
+
 # extra nice utilities!
 rpdb
 tqdm
 ipython
 flake8
+pylint
 pep8
 django-silk
 django-debug-toolbar


### PR DESCRIPTION
## Description
Adds an option  GLOBAL_LOGIN_REQUIRED (False by default) that when set to True only logged in users may visit the portal