### PR TITLE
keep pids in container scope

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV VIRTUAL_ENV=/home/mediacms.io
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ENV PIP_NO_CACHE_DIR=1
 
-RUN mkdir -p /home/mediacms.io/mediacms/{logs,pids} && cd /home/mediacms.io && python3 -m venv $VIRTUAL_ENV
+RUN mkdir -p /home/mediacms.io/mediacms/{logs} && cd /home/mediacms.io && python3 -m venv $VIRTUAL_ENV
 
 # Install dependencies:
 COPY requirements.txt .

--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -7,11 +7,11 @@ ln -sf /dev/stdout /var/log/nginx/mediacms.io.access.log && ln -sf /dev/stderr /
 
 cp /home/mediacms.io/mediacms/deploy/docker/local_settings.py /home/mediacms.io/mediacms/cms/local_settings.py
 
-mkdir -p /home/mediacms.io/mediacms/{logs,pids,media_files/hls}
+mkdir -p /home/mediacms.io/mediacms/{logs,media_files/hls}
 touch /home/mediacms.io/mediacms/logs/debug.log
 
-# Remove any dangling pids
-rm -rf /home/mediacms.io/mediacms/pids/*
+mkdir -p /var/run/mediacms
+chown www-data:www-data /var/run/mediacms
 
 TARGET_GID=$(stat -c "%g" /home/mediacms.io/mediacms/)
 

--- a/deploy/docker/reverse_proxy/client_max_body_size.conf
+++ b/deploy/docker/reverse_proxy/client_max_body_size.conf
@@ -1,1 +1,1 @@
-client_max_body_size 1g;
+client_max_body_size 5800M;

--- a/deploy/docker/supervisord/supervisord-celery_beat.conf
+++ b/deploy/docker/supervisord/supervisord-celery_beat.conf
@@ -9,4 +9,4 @@ user=www-data
 directory=/home/mediacms.io/mediacms
 priority=300
 startinorder=true
-command=/home/mediacms.io/bin/celery beat --pidfile=/home/mediacms.io/mediacms/pids/beat%%n.pid --loglevel=INFO --logfile=/home/mediacms.io/mediacms/logs/celery_beat.log
+command=/home/mediacms.io/bin/celery beat --pidfile=/var/run/mediacms/beat%%n.pid --loglevel=INFO --logfile=/home/mediacms.io/mediacms/logs/celery_beat.log

--- a/deploy/docker/supervisord/supervisord-celery_long.conf
+++ b/deploy/docker/supervisord/supervisord-celery_long.conf
@@ -10,4 +10,4 @@ directory=/home/mediacms.io/mediacms
 priority=500
 startinorder=true
 startsecs=0
-command=/home/mediacms.io/bin/celery multi start long1 --pidfile=/home/mediacms.io/mediacms/pids/%%n.pid --loglevel=INFO --logfile=/home/mediacms.io/mediacms/logs/celery_long.log -Ofair --prefetch-multiplier=1 -Q long_tasks
+command=/home/mediacms.io/bin/celery multi start long1 --pidfile=/var/run/mediacms/%%n.pid --loglevel=INFO --logfile=/home/mediacms.io/mediacms/logs/celery_long.log -Ofair --prefetch-multiplier=1 -Q long_tasks

--- a/deploy/docker/supervisord/supervisord-celery_short.conf
+++ b/deploy/docker/supervisord/supervisord-celery_short.conf
@@ -9,4 +9,4 @@ user=www-data
 directory=/home/mediacms.io/mediacms
 priority=400
 startinorder=true
-command=/home/mediacms.io/bin/celery multi start short1 short2 --pidfile=/home/mediacms.io/mediacms/pids/%%n.pid --loglevel=INFO --logfile=/home/mediacms.io/mediacms/logs/celery_short.log --soft-time-limit=300 -c10 -Q short_tasks
+command=/home/mediacms.io/bin/celery multi start short1 short2 --pidfile=/var/run/mediacms/%%n.pid --loglevel=INFO --logfile=/home/mediacms.io/mediacms/logs/celery_short.log --soft-time-limit=300 -c10 -Q short_tasks


### PR DESCRIPTION
## Description
Stores celery pids within a running container state. See: https://github.com/mediacms-io/mediacms/issues/224#issue-923117670

## Steps

*Pre-deploy*
N/A

*Post-deploy*
N/A
