### PR TITLE
shutdown migrations container when migrations have completed

### DIFF
--- a/docker-compose-http-proxy.yaml
+++ b/docker-compose-http-proxy.yaml
@@ -18,6 +18,8 @@ services:
       ENABLE_CELERY_SHORT: 'no'
       ENABLE_CELERY_LONG: 'no'
       ENABLE_CELERY_BEAT: 'no'
+    command: "./deploy/docker/prestart.sh"
+    restart: on-failure
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose-https-proxy.yaml
+++ b/docker-compose-https-proxy.yaml
@@ -20,6 +20,8 @@ services:
       ENABLE_CELERY_SHORT: 'no'
       ENABLE_CELERY_LONG: 'no'
       ENABLE_CELERY_BEAT: 'no'
+    command: "./deploy/docker/prestart.sh"
+    restart: on-failure
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose-letsencrypt.yaml
+++ b/docker-compose-letsencrypt.yaml
@@ -38,6 +38,8 @@ services:
       ENABLE_CELERY_SHORT: 'no'
       ENABLE_CELERY_LONG: 'no'
       ENABLE_CELERY_BEAT: 'no'
+    command: "./deploy/docker/prestart.sh"
+    restart: on-failure
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose-named-volumes.yaml
+++ b/docker-compose-named-volumes.yaml
@@ -11,6 +11,8 @@ services:
       ENABLE_CELERY_SHORT: 'no'
       ENABLE_CELERY_LONG: 'no'
       ENABLE_CELERY_BEAT: 'no'
+    command: "./deploy/docker/prestart.sh"
+    restart: on-failure
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,8 @@ services:
       ENABLE_CELERY_SHORT: 'no'
       ENABLE_CELERY_LONG: 'no'
       ENABLE_CELERY_BEAT: 'no'
+    command: "./deploy/docker/prestart.sh"
+    restart: on-failure
     depends_on:
       redis:
         condition: service_healthy


### PR DESCRIPTION
## Description
* Migrations are run as a pre-start process, there is no need to waste resources by unnecessarily keeping the container running when the migrations have been completed.
* This MR solves this issue

## Steps
*Pre-deploy*
N/A
*Post-deploy*
N/A

