### PR TITLE
optimize migrations service to not run all actions every time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ FROM python:3.8-slim-buster as runtime-image
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV ADMIN_USER='admin'
-ENV ADMIN_PASSWORD='mediacms'
 ENV ADMIN_EMAIL='admin@localhost'
+#ENV ADMIN_PASSWORD='uncomment_and_set_password_here'
 
 # See: https://github.com/celery/celery/issues/6285#issuecomment-715316219
 ENV CELERY_APP='cms'

--- a/deploy/docker/prestart.sh
+++ b/deploy/docker/prestart.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 RANDOM_ADMIN_PASS=`python -c "import secrets;chars = 'abcdefghijklmnopqrstuvwxyz0123456789';print(''.join(secrets.choice(chars) for i in range(10)))"`
-ADMIN_PASSWORD=${RANDOM_ADMIN_PASS:-$ADMIN_PASSWORD}
+ADMIN_PASSWORD=${ADMIN_PASSWORD:-$RANDOM_ADMIN_PASS}
 
 if [ X"$ENABLE_MIGRATIONS" = X"yes" ]; then
     echo "Running migrations service"

--- a/deploy/docker/prestart.sh
+++ b/deploy/docker/prestart.sh
@@ -1,22 +1,31 @@
 #!/bin/bash
 
 RANDOM_ADMIN_PASS=`python -c "import secrets;chars = 'abcdefghijklmnopqrstuvwxyz0123456789';print(''.join(secrets.choice(chars) for i in range(10)))"`
-ADMIN_PASSWORD=${ADMIN_PASSWORD:-$RANDOM_ADMIN_PASS}
+ADMIN_PASSWORD=${RANDOM_ADMIN_PASS:-$ADMIN_PASSWORD}
 
 if [ X"$ENABLE_MIGRATIONS" = X"yes" ]; then
+    echo "Running migrations service"
     python manage.py migrate
-    python manage.py loaddata fixtures/encoding_profiles.json
-    python manage.py loaddata fixtures/categories.json
+    EXISTING_INSTALLATION=`echo "from users.models import User; print(User.objects.exists())" |python manage.py shell`
+    if [ "$EXISTING_INSTALLATION" = "True" ]; then 
+        echo "Loaddata has already run"
+    else
+        echo "Running loaddata and creating admin user"
+        python manage.py loaddata fixtures/encoding_profiles.json
+        python manage.py loaddata fixtures/categories.json
+
+    	# post_save, needs redis to succeed (ie. migrate depends on redis)
+        DJANGO_SUPERUSER_PASSWORD=$ADMIN_PASSWORD python manage.py createsuperuser \
+            --no-input \
+            --username=admin \
+            --email=$ADMIN_EMAIL \
+            --database=default || true
+        echo "Created admin user with password: $ADMIN_PASSWORD"
+
+    fi
+    echo "RUNNING COLLECTSTATIC"
+
     python manage.py collectstatic --noinput
-
-    echo "Admin Password: $ADMIN_PASSWORD"
-
-    # post_save, needs redis to succeed (ie. migrate depends on redis)
-    DJANGO_SUPERUSER_PASSWORD=$ADMIN_PASSWORD python manage.py createsuperuser \
-        --no-input \
-        --username=$ADMIN_USER \
-        --email=$ADMIN_EMAIL \
-        --database=default || true
 
     # echo "Updating hostname ..."
     # TODO: Get the FRONTEND_HOST from cms/local_settings.py


### PR DESCRIPTION
## Description
addresses https://github.com/mediacms-io/mediacms/issues/118 , doesn't run all steps from prestart.sh every time migrations service starts but rather when DB is empty, and system is uninitialized

also sets a random password for admin (used to be a fixed pw) so update on documentation is needed