### PR TITLE
move envs from Dockerfile to docker-compose files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,6 @@ FROM python:3.8-slim-buster as runtime-image
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
-ENV ADMIN_USER='admin'
-ENV ADMIN_EMAIL='admin@localhost'
-#ENV ADMIN_PASSWORD='uncomment_and_set_password_here'
 
 # See: https://github.com/celery/celery/issues/6285#issuecomment-715316219
 ENV CELERY_APP='cms'

--- a/deploy/docker/prestart.sh
+++ b/deploy/docker/prestart.sh
@@ -17,7 +17,7 @@ if [ X"$ENABLE_MIGRATIONS" = X"yes" ]; then
     	# post_save, needs redis to succeed (ie. migrate depends on redis)
         DJANGO_SUPERUSER_PASSWORD=$ADMIN_PASSWORD python manage.py createsuperuser \
             --no-input \
-            --username=admin \
+            --username=$ADMIN_USER \
             --email=$ADMIN_EMAIL \
             --database=default || true
         echo "Created admin user with password: $ADMIN_PASSWORD"

--- a/docker-compose-http-proxy.yaml
+++ b/docker-compose-http-proxy.yaml
@@ -18,6 +18,9 @@ services:
       ENABLE_CELERY_SHORT: 'no'
       ENABLE_CELERY_LONG: 'no'
       ENABLE_CELERY_BEAT: 'no'
+      ADMIN_USER: 'admin'
+      ADMIN_EMAIL: 'admin@localhost'
+      #ADMIN_PASSWORD: 'uncomment_and_set_password_here'
     command: "./deploy/docker/prestart.sh"
     restart: on-failure
     depends_on:

--- a/docker-compose-https-proxy.yaml
+++ b/docker-compose-https-proxy.yaml
@@ -38,6 +38,9 @@ services:
       ENABLE_CELERY_SHORT: 'no'
       ENABLE_CELERY_LONG: 'no'
       ENABLE_MIGRATIONS: 'no'
+      ADMIN_USER: 'admin'
+      ADMIN_EMAIL: 'admin@localhost'
+      #ADMIN_PASSWORD: 'uncomment_and_set_password_here'
       VIRTUAL_HOST: localhost
     depends_on:
       - migrations

--- a/docker-compose-letsencrypt.yaml
+++ b/docker-compose-letsencrypt.yaml
@@ -38,6 +38,9 @@ services:
       ENABLE_CELERY_SHORT: 'no'
       ENABLE_CELERY_LONG: 'no'
       ENABLE_CELERY_BEAT: 'no'
+      ADMIN_USER: 'admin'
+      ADMIN_EMAIL: 'admin@localhost'
+      #ADMIN_PASSWORD: 'uncomment_and_set_password_here'
     command: "./deploy/docker/prestart.sh"
     restart: on-failure
     depends_on:

--- a/docker-compose-named-volumes.yaml
+++ b/docker-compose-named-volumes.yaml
@@ -11,6 +11,9 @@ services:
       ENABLE_CELERY_SHORT: 'no'
       ENABLE_CELERY_LONG: 'no'
       ENABLE_CELERY_BEAT: 'no'
+      ADMIN_USER: 'admin'
+      ADMIN_EMAIL: 'admin@localhost'
+      #ADMIN_PASSWORD: 'uncomment_and_set_password_here'
     command: "./deploy/docker/prestart.sh"
     restart: on-failure
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,9 @@ services:
       ENABLE_CELERY_SHORT: 'no'
       ENABLE_CELERY_LONG: 'no'
       ENABLE_CELERY_BEAT: 'no'
+      ADMIN_USER: 'admin'
+      ADMIN_EMAIL: 'admin@localhost'
+      #ADMIN_PASSWORD: 'uncomment_and_set_password_here'
     command: "./deploy/docker/prestart.sh"
     restart: on-failure
     depends_on:

--- a/docs/Docker_Compose.md
+++ b/docs/Docker_Compose.md
@@ -36,7 +36,7 @@ A user admin has been created with random password, you should be able to see it
 migrations_1     | Created admin user with password: gwg1clfkwf
 ```
 
-or if you have set the ADMIN_PASSWORD variable on Dockerfile, that variable will be set as the admin user's password
+or if you have set the ADMIN_PASSWORD variable on docker-compose file you have used (example `docker-compose.yaml`), that variable will be set as the admin user's password
 
 ## Update
 


### PR DESCRIPTION
## Description
Handle sensitive variables on docker-compose files rather than Dockerfile, thus changes are applied without having to build an image. 

We may optionally add env files to take care of them, but for now this fixes existing status where setting the password has no effect (same for the username)

 