### PR TITLE
Fix docker-compose version

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2.1"
 
 services:
   frontend:


### PR DESCRIPTION
# Error

![Screenshot_20220221_081136](https://user-images.githubusercontent.com/17475482/154891210-0de509db-d07c-4e64-80b0-400cba38c247.png)

```bash
cd /home/mediacms.io/mediacms
docker-compose -f docker-compose-dev.yaml up
ERROR: The Compose file './docker-compose-dev.yaml' is invalid because:
services.web.depends_on contains an invalid type, it should be an array
```

# Fix

Setting version fixes the error. Reference:

https://stackoverflow.com/a/71060305

![Screenshot_20220221_082359](https://user-images.githubusercontent.com/17475482/154891653-7ba9cda8-adde-49a3-8d2d-6bc39dd96784.png)
