### PR TITLE
Add configuration for only member access to media

### DIFF
--- a/docs/admins_docs.md
+++ b/docs/admins_docs.md
@@ -436,7 +436,10 @@ ADMINS_NOTIFICATIONS = {
 - MEDIA_ADDED: a media is added
 - MEDIA_REPORTED: the report for a media was hit
 
+### 5.23 Configure only memeber access to media
 
+- Make the portal workflow public, but at the same time set `GLOBAL_LOGIN_REQUIRED = True` so that only logged in users can see content.
+- You can either set `REGISTER_ALLOWED = False` if you want to add members yourself or checkout options on "django-allauth settings" that affects registration in `cms/settings.py`. Eg set the portal invite only, or set email confirmation as mandatory, so that you control who registers.
 
 ## 6. Manage pages
 to be written


### PR DESCRIPTION
## Description
I added an entry under 'Configuration 'per discussion in the Q&A section:
https://github.com/mediacms-io/mediacms/discussions/422

