### PR TITLE
Fix admin user creation

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -18,6 +18,10 @@ services:
       context: .
       dockerfile: ./Dockerfile-dev
     image: mediacms/mediacms-dev:latest
+    environment:
+      ADMIN_USER: "admin"
+      ADMIN_PASSWORD: "admin"
+      ADMIN_EMAIL: "admin@localhost"
     ports:
       - "80:80"
     volumes:

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -19,9 +19,9 @@ services:
       dockerfile: ./Dockerfile-dev
     image: mediacms/mediacms-dev:latest
     environment:
-      ADMIN_USER: "admin"
-      ADMIN_PASSWORD: "admin"
-      ADMIN_EMAIL: "admin@localhost"
+      ADMIN_USER: 'admin'
+      ADMIN_PASSWORD: 'admin'
+      ADMIN_EMAIL: 'admin@localhost'
     ports:
       - "80:80"
     volumes:

--- a/docs/developers_docs.md
+++ b/docs/developers_docs.md
@@ -54,6 +54,13 @@ docker-compose -f docker-compose-dev.yaml build
 docker-compose -f docker-compose-dev.yaml up
 ```
 
+An `admin` user is created during the installation process. Its attributes are defined in `docker-compose-dev.yaml`:
+```
+ADMIN_USER: 'admin'
+ADMIN_PASSWORD: 'admin'
+ADMIN_EMAIL: 'admin@localhost'
+```
+
 ### Frontend application changes
 Eg change `frontend/src/static/js/pages/HomePage.tsx` , dev application refreshes in a number of seconds (hot reloading) and I see the changes, once I'm happy I can run
 


### PR DESCRIPTION
## Description
Fix #471 by adding default values for admin user attributes in `docker-compose-dev.yaml`

A few info added to `developers_docs.md`, as well.