### PR TITLE
Add meta description tag for search engines

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -7,6 +7,7 @@ DEBUG = False
 # PORTAL NAME, this is the portal title and
 # is also shown on several places as emails
 PORTAL_NAME = "MediaCMS"
+PORTAL_DESCRIPTION = ""
 LANGUAGE_CODE = "en-us"
 TIME_ZONE = "Europe/London"
 

--- a/files/context_processors.py
+++ b/files/context_processors.py
@@ -9,6 +9,7 @@ def stuff(request):
     ret["FRONTEND_HOST"] = request.build_absolute_uri('/')
     ret["DEFAULT_THEME"] = settings.DEFAULT_THEME
     ret["PORTAL_NAME"] = settings.PORTAL_NAME
+    ret["PORTAL_DESCRIPTION"] = settings.PORTAL_DESCRIPTION
     ret["LOAD_FROM_CDN"] = settings.LOAD_FROM_CDN
     ret["CAN_LOGIN"] = settings.LOGIN_ALLOWED
     ret["CAN_REGISTER"] = settings.REGISTER_ALLOWED

--- a/templates/cms/index.html
+++ b/templates/cms/index.html
@@ -5,6 +5,8 @@
 
 <link rel="canonical" href="{{FRONTEND_HOST}}{{media_object.get_absolute_url}}">
 
+<meta name="description" content="{{PORTAL_DESCRIPTION}}">
+
 <meta property="og:title" content="{{PORTAL_NAME}}">
 <meta property="og:url" content="{{FRONTEND_HOST}}">
 <meta property="og:type" content="website">


### PR DESCRIPTION
## Description
This pull request adds the ability to specify a meta description tag for the homepage for search engines.


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

