### PR TITLE
Wrap logo in h1 tag for search engines and screenreaders

### DIFF
--- a/frontend/src/static/js/components/page-layout/PageHeader/Logo.jsx
+++ b/frontend/src/static/js/components/page-layout/PageHeader/Logo.jsx
@@ -4,9 +4,11 @@ export const Logo = ({ src, loading = 'lazy', title, alt, href = '#' }) => {
   return src ? (
     <div className="logo">
       <a href={href} title={title}>
-        <span>
-          <img src={src} alt={alt || title} title={title} loading={loading} />
-        </span>
+	<h1>
+          <span>
+            <img src={src} alt={alt || title} title={title} loading={loading} />
+          </span>
+	</h1>
       </a>
     </div>
   ) : null;

--- a/frontend/src/static/js/components/page-layout/PageHeader/PageHeader.scss
+++ b/frontend/src/static/js/components/page-layout/PageHeader/PageHeader.scss
@@ -253,6 +253,10 @@ a.user-menu-top-link {
     font-size: 1em;
   }
 
+  h1 {
+    margin: 0;
+  }
+
   a {
     color: inherit;
     display: block;


### PR DESCRIPTION
## Description
This adds an `<h1>` tag around the logo in the header, mainly to help search engines and screenreaders find the name of the site, since the rest of the page was missing header information.


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*
```
cd frontend
npm run dist
cp -ra dist/static/* ../static/
```

*Post-deploy*

