### PR TITLE
Fix double slashes in URIs

### DIFF
--- a/files/context_processors.py
+++ b/files/context_processors.py
@@ -6,7 +6,7 @@ from .methods import is_mediacms_editor, is_mediacms_manager
 def stuff(request):
     """Pass settings to the frontend"""
     ret = {}
-    ret["FRONTEND_HOST"] = request.build_absolute_uri('/')
+    ret["FRONTEND_HOST"] = request.build_absolute_uri('/').rstrip('/')
     ret["DEFAULT_THEME"] = settings.DEFAULT_THEME
     ret["PORTAL_NAME"] = settings.PORTAL_NAME
     ret["LOAD_FROM_CDN"] = settings.LOAD_FROM_CDN

--- a/templates/config/installation/site.html
+++ b/templates/config/installation/site.html
@@ -2,7 +2,7 @@ MediaCMS.site = {
  	id: 'mediacms',
     title: "{{PORTAL_NAME}}",
     url: '{{FRONTEND_HOST}}',
-    api: '{{FRONTEND_HOST}}api/v1',
+    api: '{{FRONTEND_HOST}}/api/v1',
     theme: {
     	mode: '{{DEFAULT_THEME}}',   
 		switch: {


### PR DESCRIPTION
## Description
This fixes an issue where URIs all over the system were output in the form:

```
https://example.com//view?m=(video ID)
```

...even when the `FRONTEND_HOST` and `SSL_FRONTEND_HOST` did not have a trailing slash.  This was especially problematic with the meta `canonical` tag, which was pretty much always a different URI than the page that was outputting it, but many of the other URIs on the page (especially in the metadata) were including the double slashes as well.


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

