### PR TITLE
Truncate titles and descriptions when they exceed limits

### DIFF
--- a/templates/cms/media.html
+++ b/templates/cms/media.html
@@ -11,7 +11,7 @@
 
 <meta property="og:title" content="{{media_object.title}} - {{PORTAL_NAME}}">
 <meta property="og:url" content="{{FRONTEND_HOST}}{{media_object.get_absolute_url}}">
-<meta property="og:description" content="{% if media_object.summary %}{{media_object.summary}}{% else %}{{media_object.description}}{% endif %}">
+<meta property="og:description" content="{% if media_object.summary %}{{media_object.summary|truncatechars:300}}{% else %}{{media_object.description|truncatechars:300}}{% endif %}">
 <meta property="og:updated_time" content="{{media_object.edit_date}}">
 
 {% if media_object.media_type == "video" %}

--- a/templates/cms/media.html
+++ b/templates/cms/media.html
@@ -1,13 +1,13 @@
 {% extends "base.html" %}
 {% load static %}
 
-{% block headtitle %}{{media_object.title}} - {{PORTAL_NAME}}{% endblock headtitle %}
+{% block headtitle %}{{media_object.title|add:" - "|add:PORTAL_NAME|truncatechars:64}}{% endblock headtitle %}
 
 {% block headermeta %}
 
 <link rel="canonical" href="{{FRONTEND_HOST}}{{media_object.get_absolute_url}}">
 
-<meta name="description" content="{% if media_object.summary %}{{media_object.summary}}{% else %}{{media_object.description}}{% endif %}">
+<meta name="description" content="{% if media_object.summary %}{{media_object.summary|truncatechars:160}}{% else %}{{media_object.description|truncatechars:160}}{% endif %}">
 
 <meta property="og:title" content="{{media_object.title}} - {{PORTAL_NAME}}">
 <meta property="og:url" content="{{FRONTEND_HOST}}{{media_object.get_absolute_url}}">


### PR DESCRIPTION
## Description
Users on an instance I'm running like to use really long titles and descriptions.  Per:

https://www.w3.org/Provider/Style/TITLE.html#:~:text=The%20title%20should%20ideally%20be,there%20is%20only%20limited%20room.

...titles should only be 64 characters long, and meta descriptions should usually be limited to 160 characters.  This change truncates both if they exceed limits to keep things in compliance.


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

