### PR TITLE
Cross-browser event path

### DIFF
--- a/frontend/src/static/js/components/_shared/popup/PopupContent.jsx
+++ b/frontend/src/static/js/components/_shared/popup/PopupContent.jsx
@@ -16,8 +16,23 @@ export function PopupContent(props) {
 
     const domElem = findDOMNode(wrapperRef.current);
 
-    if (-1 === ev.path.indexOf(domElem)) {
-      hide();
+    // To avoid this error on Firefox:
+    // Uncaught TypeError: e.path is undefined
+    // And this error on Chromium:
+    // Uncaught TypeError: Cannot read properties of undefined (reading 'indexOf')
+    //
+    // https://stackoverflow.com/a/39245638/3405291
+    //
+    // It allows for both the old way and the new, standard way.
+    // So will do its best cross-browser.
+    var path = ev.path || (ev.composedPath && ev.composedPath());
+    if (path) {
+      if (-1 === path.indexOf(domElem)) {
+        hide();
+      }
+    } else {
+      Console.log("This browser doesn't supply event path information")
+      // TODO: Should call hide()?
     }
   }, []);
 


### PR DESCRIPTION
Fix errors on web browsers due to usage of the  non-standard `path` property of event objects:

Firefox:

![Screenshot_20221218_181237--crop](https://user-images.githubusercontent.com/95064217/208313567-c59babe4-9711-4315-a135-5283ce892cb3.png)

Chromium:

![Screenshot_20221218_181541--crop](https://user-images.githubusercontent.com/95064217/208313574-d4a827ce-0a6f-4dd7-b8b9-acd6a75d875a.png)

# Test

Tests indicate that the errors are resolved.