### PR TITLE
ansible playbook 

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,11 @@
+[defaults]
+inventory  = hosts
+host_key_checking = False
+deprecation_warnings = False
+roles_path = roles
+
+[ssh_connection]
+# ssh arguments to use
+# Leaving off ControlPersist will result in poor performance, so use
+# paramiko on older platforms rather than removing it, -C controls compression use
+ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s -o ForwardAgent=yes

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -1,0 +1,17 @@
+# only one media server can be added, at the moment there is no celery queue separation at the redis level, which implies coding errors
+
+[mediacms_servers]
+testmediacms1 ansible_port=22
+
+# If postgresql_servers is declared, it must contain a single host.
+# Only Debian bullseye postgresql server allowed.
+# Remote postgresql servers must have python3-psycopg2 package installed and listen on default port 5432.
+
+[postgresql_servers]
+postgresql ansible_port=22
+
+# if redis_servers is declared, it must contain a single host.
+# settings.py is set automatically.
+
+[redis_servers]
+redis ansible_port=22

--- a/ansible/playbooks/01_system_deploy.yml
+++ b/ansible/playbooks/01_system_deploy.yml
@@ -1,0 +1,378 @@
+- hosts: mediacms_servers
+  remote_user: root
+  gather_facts: yes
+  vars:
+    # each host in mediacms group gets a different UUID
+    # this is for postgresql db/roles separation
+    UUID: "{{ ansible_date_time.iso8601_micro | to_uuid }}"
+
+    # mediacms DATABASES in settings.py
+    # users and databases will be automatically created in postgresql
+    POSTGRESQL_USER: "mediacms_{{ UUID }}"
+    POSTGRESQL_PASSWD: "changeme"
+    POSTGRESQL_DATABASE: "mediacms_{{ UUID }}"
+
+    # do not change
+    postgresql_admin_user: "postgres"
+    postgresql_preinstalled_db: "postgres"
+
+    #############################################
+    # settings.py defaults values.
+    # For test environment it will work, for production you must edit.
+    #############################################
+
+    # at the moment only localhost allowed (SSL)
+    # playbook doesn't handle certbot with nginx for another hosts (Will be implemented soon)
+    # do not change
+    FRONTEND_HOST: "http://localhost"
+    FRONTEND_HOST_DOMAIN: "localhost"
+
+    # SECRET_KEY is generated automatically in setup
+    # SECRET_KEY = "2dii4cog7k=5n37$fz)8dst)kg(s3&10)^qa*gv(kk+nv-z&cu"
+
+    PORTAL_NAME: "MediaCMS"
+    PORTAL_DESCRIPTION: "MediaCMS test server"
+    LANGUAGE_CODE: "en-us"
+    TIME_ZONE: "Europe/London"
+
+    # who can add media
+    # valid options include 'all', 'email_verified', 'advancedUser'
+    CAN_ADD_MEDIA: "all"
+
+    # valid choices here are 'public', 'private', 'unlisted
+    PORTAL_WORKFLOW: "public"
+
+    # valid values: 'light', 'dark'.
+    DEFAULT_THEME: "light"
+
+    # These are passed on every request
+    # if set to False will not fetch external content
+    # this is only for the static files, as fonts/css/js files loaded from CDNs
+    # not for user uploaded media!
+    LOAD_FROM_CDN: False
+    LOGIN_ALLOWED: True  # whether the login button appears
+    REGISTER_ALLOWED: True  # whether the register button appears
+    UPLOAD_MEDIA_ALLOWED: True  # whether the upload media button appears
+    CAN_LIKE_MEDIA: True  # whether the like media appears
+    CAN_DISLIKE_MEDIA: True  # whether the dislike media appears
+    CAN_REPORT_MEDIA: True  # whether the report media appears
+    CAN_SHARE_MEDIA: True  # whether the share media appears
+
+    # how many times an item need be reported
+    # to get to private state automatically
+    REPORTED_TIMES_THRESHOLD: 10
+    ALLOW_ANONYMOUS_ACTIONS: ["report", "like", "dislike", "watch"]  # need be a list
+
+    # ip of the server should be part of this
+    ALLOWED_HOSTS: ["*", "mediacms.io", "127.0.0.1", "localhost", "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"]
+
+    VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE: False
+    PRE_UPLOAD_MEDIA_MESSAGE: ""
+
+    # email settings
+    DEFAULT_FROM_EMAIL: "info@mediacms.io"
+    EMAIL_HOST_PASSWORD: "xyz"
+    EMAIL_HOST_USER: "info@mediacms.io"
+    EMAIL_USE_TLS: True
+    SERVER_EMAIL: "info@mediacms.io"
+    EMAIL_HOST: "mediacms.io"
+    EMAIL_PORT: 587
+    ADMIN_EMAIL_LIST: ["info@mediacms.io"]
+
+    MEDIA_IS_REVIEWED: True  # whether an admin needs to review a media file.
+    # By default consider this is not needed.
+    # If set to False, then each new media need be reviewed otherwise
+    # it won't appear on public listings
+
+    # if set to True the url for original file is returned to the API.
+    SHOW_ORIGINAL_MEDIA: True
+    # Keep in mind that nginx will serve the file unless there's
+    # some authentication taking place. Check nginx file and setup a
+    # basic http auth user/password if you want to restrict access
+
+    MAX_MEDIA_PER_PLAYLIST: 70
+    # bytes, size of uploaded media
+    UPLOAD_MAX_SIZE:  "800 * 1024 * 1000 * 5"
+
+    MAX_CHARS_FOR_COMMENT: 10000  # so that it doesn't end up huge
+    TIMESTAMP_IN_TIMEBAR: False  # shows timestamped comments in the timebar for videos
+    ALLOW_MENTION_IN_COMMENTS: False  # allowing to mention other users with @ in the comments
+
+    # valid options: content, author
+    RELATED_MEDIA_STRATEGY: "content"
+
+    USE_I18N: True
+    USE_L10N: True
+    USE_TZ: True
+    SITE_ID: 1
+
+    # protection agains anonymous users
+    # per ip address limit, for actions as like/dislike/report
+    TIME_TO_ACTION_ANONYMOUS: 10 * 60
+
+    # django-allauth settings
+    ACCOUNT_SESSION_REMEMBER: True
+    ACCOUNT_AUTHENTICATION_METHOD: "username_email"
+    ACCOUNT_EMAIL_REQUIRED: True  # new users need to specify email
+    ACCOUNT_EMAIL_VERIFICATION: "optional"  # 'mandatory' 'none'
+    ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION: True
+    ACCOUNT_USERNAME_MIN_LENGTH: "4"
+    ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE: False
+    ACCOUNT_USERNAME_REQUIRED: True
+    ACCOUNT_LOGIN_ON_PASSWORD_RESET: True
+    ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS: 1
+    ACCOUNT_LOGIN_ATTEMPTS_LIMIT: 20
+    ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT: 5
+    # registration won't be open, might also consider to remove links for register
+    USERS_CAN_SELF_REGISTER: True
+
+    RESTRICTED_DOMAINS_FOR_USER_REGISTRATION: ["xxx.com", "emaildomainwhatever.com"]
+
+    MASK_IPS_FOR_ACTIONS: True
+    # how many seconds a process in running state without reporting progress is
+    # considered as stale...unfortunately v9 seems to not include time
+    # some times so raising this high
+    RUNNING_STATE_STALE: "60 * 60 * 2"
+
+    FRIENDLY_TOKEN_LEN: 9
+
+    # for videos, after that duration get split into chunks
+    # and encoded independently
+    CHUNKIZE_VIDEO_DURATION: "60 * 5"
+    # aparently this has to be smaller than VIDEO_CHUNKIZE_DURATION
+    VIDEO_CHUNKS_DURATION: "60 * 4"
+
+    # always get these two, even if upscaling
+    MINIMUM_RESOLUTIONS_TO_ENCODE: [240, 360]
+
+    LOCAL_INSTALL: True
+
+    # this is an option to make the whole portal available to logged in users only
+    # it is placed here so it can be overrided on local_settings.py
+    GLOBAL_LOGIN_REQUIRED: False
+
+
+  tasks:
+
+    - name: Setup
+      ansible.builtin.include_tasks:
+        file: setup.yml
+
+
+    # pass all variables directly to settings.py, local_settings.py not used
+    - name: Template settings.py
+      ansible.builtin.template:
+        src: ../templates/settings_template.yml
+        dest: /home/mediacms.io/mediacms/cms/settings.py
+        owner: root
+        group: root
+        mode: '0600'
+
+
+    - name: manage.py migrate
+      ansible.builtin.command: /home/mediacms.io/bin/python3 manage.py migrate
+      register: migrate
+      args:
+        chdir: /home/mediacms.io/mediacms/
+
+
+    - debug:
+        msg: "manage.py migrate output: {{ migrate.stdout }}"
+
+
+    - name: manage.py loaddata encoding_profiles.json
+      ansible.builtin.command: /home/mediacms.io/bin/python3 manage.py loaddata /home/mediacms.io/mediacms/fixtures/encoding_profiles.json
+      register: loaddata_e
+      args:
+        chdir: /home/mediacms.io/mediacms/
+
+
+    - debug:
+        msg: "manage.py loaddata output: {{ loaddata_e.stdout }}"
+
+
+    - name: loaddata fixtures/categories.json
+      ansible.builtin.command: /home/mediacms.io/bin/python3 manage.py loaddata /home/mediacms.io/mediacms/fixtures/categories.json
+      register: loaddata_f
+      args:
+        chdir: /home/mediacms.io/mediacms/
+
+
+    - debug:
+        msg: "loaddata fixtures/categories.json output: {{ loaddata_f.stdout }}"
+
+
+    - name: manage.py collectstatic
+      ansible.builtin.command: /home/mediacms.io/bin/python3 manage.py collectstatic --noinput
+      register: collectstatic
+      args:
+        chdir: /home/mediacms.io/mediacms/
+
+
+    - debug:
+        msg: "collectstatic output: {{ collectstatic.stdout }}"
+
+
+    - name: generate ADMIN_PASS
+      ansible.builtin.shell: /home/mediacms.io/bin/python3 -c "import secrets;chars = 'abcdefghijklmnopqrstuvwxyz0123456789';print(''.join(secrets.choice(chars) for i in range(10)))"
+      register: admin_pass
+      args:
+        chdir: /home/mediacms.io/mediacms/
+
+    - name: Set ADMIN_PASS
+      ansible.builtin.set_fact: ADMIN_PASS="{{ admin_pass.stdout }}"
+
+
+    - debug:
+        msg: "ADMIN_PASS: {{ ADMIN_PASS }}"
+
+
+    - name: insert ADMIN_PASS on model
+      ansible.builtin.shell: echo "from users.models import User; User.objects.create_superuser('admin', 'admin@example.com', '{{ ADMIN_PASS }}')" | /home/mediacms.io/bin/python3 manage.py shell
+      register: insert_admin_pass
+      args:
+        chdir: /home/mediacms.io/mediacms/
+
+
+    - debug:
+        msg: "insert ADMIN_PASS output: {{ insert_admin_pass }}"
+
+
+    - name: insert FRONTEND_HOST_DOMAIN on model
+      ansible.builtin.shell: echo "from django.contrib.sites.models import Site; Site.objects.update(name='{{ FRONTEND_HOST_DOMAIN }}', domain='{{ FRONTEND_HOST_DOMAIN }}')" | /home/mediacms.io/bin/python3 manage.py shell
+      register: insert_fronted_host_domain
+      args:
+        chdir: /home/mediacms.io/mediacms/
+
+
+    - debug:
+        msg: "insert FRONTEND_HOST_DOMAIN output: {{ insert_fronted_host_domain }}"
+
+
+    - name: Recursively change ownership of /home/mediacms.io/
+      ansible.builtin.file:
+        path: /home/mediacms.io
+        state: directory
+        recurse: yes
+        owner: www-data
+        group: www-data
+
+    - name: copy celery systemd units
+      ansible.builtin.copy:
+       src: "/home/mediacms.io/mediacms/deploy/local_install/{{ item }}"
+       dest: "/etc/systemd/system/{{ item }}"
+       remote_src: true
+      with_items: [celery_long.service, celery_short.service, celery_beat.service, mediacms.service]
+
+
+    - name: Generat nginx dirs
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+      with_items: ['/etc/letsencrypt/live/mediacms.io/', '/etc/letsencrypt/live/{{ FRONTEND_HOST_DOMAIN }}', '/etc/nginx/sites-enabled', '/etc/nginx/sites-available', '/etc/nginx/dhparams/']
+
+
+    - name: delete some nginx files
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      with_items: ['/etc/nginx/conf.d/default.conf', '/etc/nginx/sites-enabled/default']
+
+
+    - name: copy fullchain.pem
+      ansible.builtin.copy:
+       src: /home/mediacms.io/mediacms/deploy/local_install/mediacms.io_fullchain.pem
+       dest: "/etc/letsencrypt/live/{{ FRONTEND_HOST_DOMAIN }}/fullchain.pem"
+       remote_src: true
+
+
+    - name: copy privkey.pem
+      ansible.builtin.copy:
+       src: /home/mediacms.io/mediacms/deploy/local_install/mediacms.io_privkey.pem
+       dest: "/etc/letsencrypt/live/{{ FRONTEND_HOST_DOMAIN }}/privkey.pem"
+       remote_src: true
+
+
+    - name: copy dhparams.pem
+      ansible.builtin.copy:
+       src: /home/mediacms.io/mediacms/deploy/local_install/dhparams.pem
+       dest: /etc/nginx/dhparams/dhparams.pem
+       remote_src: true
+
+
+    - name: copy mediacms.io
+      ansible.builtin.copy:
+       src: /home/mediacms.io/mediacms/deploy/local_install/mediacms.io
+       dest: /etc/nginx/sites-available/mediacms.io
+       remote_src: true
+
+
+    - name: symbolic link to /etc/nginx/sites-enabled/mediacms.io
+      ansible.builtin.file:
+        src: /etc/nginx/sites-available/mediacms.io
+        dest: /etc/nginx/sites-enabled/mediacms.io
+        state: link
+
+
+    - name: copy uwsgi_params
+      ansible.builtin.copy:
+       src: /home/mediacms.io/mediacms/deploy/local_install/uwsgi_params
+       dest: /etc/nginx/sites-enabled/uwsgi_params
+       remote_src: true
+
+
+    - name: copy nginx.conf
+      ansible.builtin.copy:
+       src: /home/mediacms.io/mediacms/deploy/local_install/nginx.conf
+       dest: /etc/nginx/nginx.conf
+       remote_src: true
+
+
+    - name: restart nginx
+      ansible.builtin.systemd:
+       name: nginx
+       state: restarted
+
+
+    - name: Recursively change ownership of /home/mediacms.io/
+      ansible.builtin.file:
+        path: /home/mediacms.io
+        state: directory
+        recurse: yes
+        owner: www-data
+        group: www-data
+
+
+    - name: enable and start systemd units
+      ansible.builtin.systemd:
+       name: '{{ item }}'
+       enabled: yes
+       state: restarted
+       daemon_reload: yes
+      with_items: [celery_long, celery_short, celery_beat, mediacms]
+
+
+    - name: Check install
+      uri:
+        url: "http://{{ ansible_default_ipv4.address }}"
+        method: GET
+        status_code: [200]
+      register: result
+      until: result.status == 200
+      retries: 3
+      delay: 5
+
+
+    # ugly hack in case mediacms is not up
+    # it may take a while
+    - name: restart mediacms
+      ansible.builtin.systemd:
+       name: '{{ item }}'
+       enabled: yes
+       state: restarted
+       daemon_reload: yes
+      with_items: [mediacms]
+      when: "result.status != 200"
+
+    - debug:
+        msg: "MediaCMS installation completed, open browser on http://{{ FRONTEND_HOST_DOMAIN }} and login with user admin and password {{ ADMIN_PASS }}"

--- a/ansible/playbooks/setup.yml
+++ b/ansible/playbooks/setup.yml
@@ -1,0 +1,244 @@
+- name: Check if Debian
+  ansible.builtin.fail:
+    msg: Only Debian
+  when: ansible_distribution != 'Debian'
+
+
+- name: Check if bullseye
+  ansible.builtin.fail:
+    msg: Only Debian
+  when: ansible_distribution_release != 'bullseye'
+
+
+- name: Check postgresql_servers group
+  ansible.builtin.fail:
+    msg: Only one host in postgresql_servers
+  when:
+    - "'postgresql_servers' in groups"
+    - "groups['postgresql_servers']|length != 1"
+
+
+- name: Check redis_servers group
+  ansible.builtin.fail:
+    msg: Only one host in redis_servers
+  when:
+    - "'redis_servers' in groups"
+    - "groups['redis_servers']|length != 1"
+
+
+- name: Gather facts from postgresql servers
+  ansible.builtin.setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  loop: "{{ groups['postgresql_servers'] }}"
+  when:
+    - "'postgresql_servers' in groups"
+
+
+- name: Check if postgresql server is Debian
+  ansible.builtin.fail:
+    msg: Only Debian
+  when:
+    - "'postgresql_servers' in groups"
+    - hostvars[groups['postgresql_servers'][0]]['ansible_distribution'] != 'Debian'
+
+
+- name: Check if postgresql server is bullseye
+  ansible.builtin.fail:
+    msg: Only Debian
+  when:
+    - "'postgresql_servers' in groups"
+    - hostvars[groups['postgresql_servers'][0]]['ansible_distribution_release'] != 'bullseye'
+
+
+- name: Gather facts from redis servers
+  ansible.builtin.setup:
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  loop: "{{ groups['redis_servers'] }}"
+  when:
+    - "'redis_servers' in groups"
+
+
+- name: Set POSTGRESQL_IP vars
+  ansible.builtin.set_fact:
+    POSTGRESQL_IP: "{{ hostvars[groups['postgresql_servers'][0]]['ansible_default_ipv4']['address'] }}"
+  when:
+    - "'postgresql_servers' in groups"
+
+
+- name: Set POSTGRESQL_IP vars
+  ansible.builtin.set_fact:
+    POSTGRESQL_IP: "127.0.0.1"
+  when:
+    - "'postgresql_servers' not in groups"
+
+
+- name: Set REDIS_IP & POSTGRESQL_IP vars
+  ansible.builtin.set_fact:
+    REDIS_IP: "{{ hostvars[groups['redis_servers'][0]]['ansible_default_ipv4']['address'] }}"
+  when:
+    - "'redis_servers' in groups"
+
+
+- name: Set REDIS_IP & POSTGRESQL_IP vars
+  ansible.builtin.set_fact:
+    REDIS_IP: "127.0.0.1"
+  when:
+    - "'redis_servers' not in groups"
+
+
+- name: test postgresql
+  community.postgresql.postgresql_query:
+    db: "{{ postgresql_preinstalled_db }}"
+    query: SELECT version()
+  become: true
+  become_user: "{{ postgresql_admin_user }}"
+  delegate_to: "{{ POSTGRESQL_IP }}"
+  register: sql_data
+  when:
+    - "'redis_servers' in groups"
+
+
+- ansible.builtin.debug:
+    var: sql_data.query_result.0.version
+  when:
+    - "'redis_servers' in groups"
+
+
+- name: Installs software-properties-common
+  ansible.builtin.apt:
+    name: [software-properties-common]
+    state: latest
+
+
+- name: Installs repos
+  ansible.builtin.command: "add-apt-repository -y {{ item }}"
+  with_items: [contrib, non-free]
+
+
+- name: Update apt-get repo and cache
+  ansible.builtin.apt:
+    update_cache: yes
+    force_apt_get: yes
+    cache_valid_time: 3600
+    upgrade: yes
+
+
+- name: Installs common packages
+  ansible.builtin.apt:
+    name: [python3-venv, python3-dev, virtualenv, nginx, git, gcc, vim, unzip, imagemagick, python3-certbot-nginx, certbot, wget, xz-utils]
+    state: latest
+
+
+- name: Installs redis-server if neccesary
+  ansible.builtin.apt:
+    name: [redis-server]
+    state: latest
+  when: REDIS_IP == "127.0.0.1"
+
+
+- name: Installs postgresql if neccesary
+  ansible.builtin.apt:
+    name: [postgresql]
+    state: latest
+  when: POSTGRESQL_IP == "127.0.0.1"
+
+
+- debug:
+    msg: "POSTGRESQL_IP: {{ POSTGRESQL_IP }}, REDIS_IP: {{ REDIS_IP }}, POSTGRESQL_USER: {{ POSTGRESQL_USER }}, POSTGRESQL_PASSWD: {{ POSTGRESQL_PASSWD }}, POSTGRESQL_DATABASE: {{ POSTGRESQL_DATABASE }}"
+
+
+- name: "create postgresql users"
+  become: yes
+  become_user: "{{ postgresql_admin_user }}"
+  delegate_to: "{{ POSTGRESQL_IP }}"
+  community.general.postgresql_user:
+    name: "{{ POSTGRESQL_USER }}"
+    password: "{{ POSTGRESQL_PASSWD }}"
+    encrypted: True
+    expires: "infinity"
+
+
+- name: "create postgresql dbs"
+  become: yes
+  become_user: "{{ postgresql_admin_user }}"
+  delegate_to: "{{ POSTGRESQL_IP }}"
+  community.general.postgresql_db:
+    name: "{{ POSTGRESQL_DATABASE }}"
+    owner: "{{ POSTGRESQL_USER }}"
+    template: template0
+    encoding: UTF8
+
+
+- name: Unarchive ffmpeg
+  ansible.builtin.unarchive:
+    src: https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
+    creates: /usr/src/ffmpeg-6.0-amd64-static
+    dest: /usr/src
+    remote_src: yes
+
+
+- name: Install ffmpeg
+  ansible.builtin.copy:
+    src: '/usr/src/ffmpeg-6.0-amd64-static/{{ item }}'
+    dest: '/usr/local/bin/{{ item }}'
+    owner: root
+    group: root
+    mode: '0777'
+    remote_src: yes
+  with_items: [ffmpeg, ffprobe, qt-faststart]
+
+
+- name: Delete git clone if exists
+  ansible.builtin.file:
+    state: absent
+    path: /home/mediacms.io/mediacms
+
+
+- name: Clona
+  ansible.builtin.git:
+    repo: 'git@github.com:mediacms-io/mediacms.git'
+    dest: /home/mediacms.io/mediacms
+    clone: yes
+    accept_hostkey: yes
+    force: true
+
+
+- name: virtual env and libs
+  ansible.builtin.pip:
+   virtualenv: /home/mediacms.io/
+   virtualenv_command: /usr/bin/python3 -m venv
+   extra_args: --upgrade pip
+   requirements: /home/mediacms.io/mediacms/requirements.txt
+
+
+- name: SECRET_KEY
+  ansible.builtin.command: /home/mediacms.io/bin/python3 -c 'from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())'
+  register: SECRET_KEY
+
+
+- set_fact:
+      SECRET_KEY: '{{ SECRET_KEY.stdout }}'
+
+
+- name: Create a directory if it does not exist
+  ansible.builtin.file:
+    path: '/home/mediacms.io/mediacms/{{ item }}'
+    state: directory
+    mode: '0755'
+  with_items: [logs, pids]
+
+
+- name: Unarchive Bento4
+  ansible.builtin.unarchive:
+    src: http://zebulon.bok.net/Bento4/binaries/Bento4-SDK-1-6-0-637.x86_64-unknown-linux.zip
+    creates: /home/mediacms.io/mediacms/Bento4-SDK-1-6-0-637.x86_64-unknown-linux
+    dest: /home/mediacms.io/mediacms/
+    remote_src: yes
+
+
+- name: hls dir
+  ansible.builtin.file:
+    path: /home/mediacms.io/mediacms/media_files/hls
+    state: directory

--- a/ansible/playbooks/setup.yml
+++ b/ansible/playbooks/setup.yml
@@ -60,55 +60,23 @@
     - "'redis_servers' in groups"
 
 
-- name: Set POSTGRESQL_IP vars
+- name: Set POSTGRESQL_IP
   ansible.builtin.set_fact:
     POSTGRESQL_IP: "{{ hostvars[groups['postgresql_servers'][0]]['ansible_default_ipv4']['address'] }}"
   when:
     - "'postgresql_servers' in groups"
 
 
-- name: Set POSTGRESQL_IP vars
-  ansible.builtin.set_fact:
-    POSTGRESQL_IP: "127.0.0.1"
-  when:
-    - "'postgresql_servers' not in groups"
-
-
-- name: Set REDIS_IP & POSTGRESQL_IP vars
+- name: Set REDIS_IP
   ansible.builtin.set_fact:
     REDIS_IP: "{{ hostvars[groups['redis_servers'][0]]['ansible_default_ipv4']['address'] }}"
   when:
     - "'redis_servers' in groups"
 
 
-- name: Set REDIS_IP & POSTGRESQL_IP vars
-  ansible.builtin.set_fact:
-    REDIS_IP: "127.0.0.1"
-  when:
-    - "'redis_servers' not in groups"
-
-
-- name: test postgresql
-  community.postgresql.postgresql_query:
-    db: "{{ postgresql_preinstalled_db }}"
-    query: SELECT version()
-  become: true
-  become_user: "{{ postgresql_admin_user }}"
-  delegate_to: "{{ POSTGRESQL_IP }}"
-  register: sql_data
-  when:
-    - "'redis_servers' in groups"
-
-
-- ansible.builtin.debug:
-    var: sql_data.query_result.0.version
-  when:
-    - "'redis_servers' in groups"
-
-
 - name: Installs software-properties-common
   ansible.builtin.apt:
-    name: [software-properties-common]
+    name: [software-properties-common, sudo, python3-psycopg2]
     state: latest
 
 
@@ -135,21 +103,47 @@
   ansible.builtin.apt:
     name: [redis-server]
     state: latest
-  when: REDIS_IP == "127.0.0.1"
+  when: REDIS_IP is not defined
 
 
 - name: Installs postgresql if neccesary
   ansible.builtin.apt:
     name: [postgresql]
     state: latest
-  when: POSTGRESQL_IP == "127.0.0.1"
+  when: POSTGRESQL_IP is not defined
 
 
-- debug:
-    msg: "POSTGRESQL_IP: {{ POSTGRESQL_IP }}, REDIS_IP: {{ REDIS_IP }}, POSTGRESQL_USER: {{ POSTGRESQL_USER }}, POSTGRESQL_PASSWD: {{ POSTGRESQL_PASSWD }}, POSTGRESQL_DATABASE: {{ POSTGRESQL_DATABASE }}"
+- name: test remote postgresql
+  community.postgresql.postgresql_query:
+    db: "{{ postgresql_preinstalled_db }}"
+    query: SELECT version()
+  become: true
+  become_user: "{{ postgresql_admin_user }}"
+  delegate_to: "{{ POSTGRESQL_IP }}"
+  register: sql_data
+  when: POSTGRESQL_IP is defined
+
+- ansible.builtin.debug:
+    var: sql_data.query_result.0.version
+  when: POSTGRESQL_IP is defined
 
 
-- name: "create postgresql users"
+- name: test local postgresql
+  community.postgresql.postgresql_query:
+    db: "{{ postgresql_preinstalled_db }}"
+    query: SELECT version()
+  become: true
+  become_user: "{{ postgresql_admin_user }}"
+  register: sql_data
+  when: POSTGRESQL_IP is not defined
+
+
+- ansible.builtin.debug:
+    var: sql_data.query_result.0.version
+  when: POSTGRESQL_IP is not defined
+
+
+- name: "create remote postgresql users"
   become: yes
   become_user: "{{ postgresql_admin_user }}"
   delegate_to: "{{ POSTGRESQL_IP }}"
@@ -158,9 +152,21 @@
     password: "{{ POSTGRESQL_PASSWD }}"
     encrypted: True
     expires: "infinity"
+  when: POSTGRESQL_IP is defined
 
 
-- name: "create postgresql dbs"
+- name: "create local postgresql users"
+  become: yes
+  become_user: "{{ postgresql_admin_user }}"
+  community.general.postgresql_user:
+    name: "{{ POSTGRESQL_USER }}"
+    password: "{{ POSTGRESQL_PASSWD }}"
+    encrypted: True
+    expires: "infinity"
+  when: POSTGRESQL_IP is not defined
+
+
+- name: "create remote postgresql dbs"
   become: yes
   become_user: "{{ postgresql_admin_user }}"
   delegate_to: "{{ POSTGRESQL_IP }}"
@@ -169,6 +175,31 @@
     owner: "{{ POSTGRESQL_USER }}"
     template: template0
     encoding: UTF8
+  when: POSTGRESQL_IP is defined
+
+
+- name: "create local postgresql dbs"
+  become: yes
+  become_user: "{{ postgresql_admin_user }}"
+  community.general.postgresql_db:
+    name: "{{ POSTGRESQL_DATABASE }}"
+    owner: "{{ POSTGRESQL_USER }}"
+    template: template0
+    encoding: UTF8
+  when: POSTGRESQL_IP is not defined
+
+
+- debug:
+    msg: "POSTGRESQL SERVER: {{POSTGRESQL_IP }}"
+  when: POSTGRESQL_IP is defined
+
+
+- debug:
+    msg: "POSTGRESQL SERVER: 127.0.0.1"
+  when: POSTGRESQL_IP is not defined
+
+- debug:
+    msg: "POSTGRESQL_USER: {{ POSTGRESQL_USER }}, POSTGRESQL_PASSWD: {{ POSTGRESQL_PASSWD }}, POSTGRESQL_DATABASE: {{ POSTGRESQL_DATABASE }}"
 
 
 - name: Unarchive ffmpeg
@@ -190,13 +221,13 @@
   with_items: [ffmpeg, ffprobe, qt-faststart]
 
 
-- name: Delete git clone if exists
+- name: Delete git clone, if exists
   ansible.builtin.file:
     state: absent
     path: /home/mediacms.io/mediacms
 
 
-- name: Clona
+- name: git clone
   ansible.builtin.git:
     repo: 'git@github.com:mediacms-io/mediacms.git'
     dest: /home/mediacms.io/mediacms

--- a/ansible/templates/settings_template.yml
+++ b/ansible/templates/settings_template.yml
@@ -388,7 +388,7 @@ DATABASES = {
     "default": {
         "ENGINE": "django.db.backends.postgresql",
         "NAME": "{{ POSTGRESQL_DATABASE }}",
-        "HOST": "{{ POSTGRESQL_IP }}",
+        "HOST": "{{ POSTGRESQL_IP | default('127.0.0.1') }}",
         "PORT": "5432",
         "USER": "{{ POSTGRESQL_USER }}",
         "PASSWORD": "{{ POSTGRESQL_PASSWD }}",
@@ -396,7 +396,7 @@ DATABASES = {
 }
 
 
-REDIS_LOCATION = "redis://{{ REDIS_IP }}:6379/1"
+REDIS_LOCATION = "redis://{{ REDIS_IP | default('127.0.0.1') }}:6379/1"
 CACHES = {
     "default": {
         "BACKEND": "django_redis.cache.RedisCache",

--- a/ansible/templates/settings_template.yml
+++ b/ansible/templates/settings_template.yml
@@ -1,0 +1,485 @@
+import os
+
+from celery.schedules import crontab
+
+DEBUG = False
+
+# PORTAL NAME, this is the portal title and
+# is also shown on several places as emails
+PORTAL_NAME = "{{ PORTAL_NAME }}"
+PORTAL_DESCRIPTION = "{{ PORTAL_DESCRIPTION }}"
+LANGUAGE_CODE = "{{ LANGUAGE_CODE }}"
+TIME_ZONE = "{{ TIME_ZONE }}"
+
+# who can add media
+# valid options include 'all', 'email_verified', 'advancedUser'
+CAN_ADD_MEDIA = "{{ CAN_ADD_MEDIA }}"
+
+# valid choices here are 'public', 'private', 'unlisted
+PORTAL_WORKFLOW = "{{ PORTAL_WORKFLOW}}"
+
+# valid values: 'light', 'dark'.
+DEFAULT_THEME = "{{ DEFAULT_THEME }}"
+
+
+# These are passed on every request
+# if set to False will not fetch external content
+# this is only for the static files, as fonts/css/js files loaded from CDNs
+# not for user uploaded media!
+LOAD_FROM_CDN = {{ LOAD_FROM_CDN }}
+LOGIN_ALLOWED = {{ LOGIN_ALLOWED }}  # whether the login button appears
+REGISTER_ALLOWED = {{ REGISTER_ALLOWED }}  # whether the register button appears
+UPLOAD_MEDIA_ALLOWED = {{ UPLOAD_MEDIA_ALLOWED }}  # whether the upload media button appears
+CAN_LIKE_MEDIA = {{ CAN_LIKE_MEDIA }}  # whether the like media appears
+CAN_DISLIKE_MEDIA = {{ CAN_DISLIKE_MEDIA }}  # whether the dislike media appears
+CAN_REPORT_MEDIA = {{ CAN_REPORT_MEDIA }}  # whether the report media appears
+CAN_SHARE_MEDIA = {{ CAN_SHARE_MEDIA }}  # whether the share media appears
+# how many times an item need be reported
+# to get to private state automatically
+REPORTED_TIMES_THRESHOLD = {{ REPORTED_TIMES_THRESHOLD }}
+ALLOW_ANONYMOUS_ACTIONS = {{ ALLOW_ANONYMOUS_ACTIONS }}  # need be a list
+
+# experimental functionality for user ratings - does not work
+ALLOW_RATINGS = False
+ALLOW_RATINGS_CONFIRMED_EMAIL_ONLY = True
+
+# ip of the server should be part of this
+ALLOWED_HOSTS = {{ ALLOWED_HOSTS }}
+
+FRONTEND_HOST = "{{ FRONTEND_HOST }}"
+# this variable - along with SSL_FRONTEND_HOST is used on several places
+# as email where a URL need appear etc
+
+# FRONTEND_HOST needs an http prefix - at the end of the file
+# there's a conversion to https with the SSL_FRONTEND_HOST env
+INTERNAL_IPS = "127.0.0.1"
+
+# settings that are related with UX/appearance
+# whether a featured item appears enlarged with player on index page
+VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE = {{ VIDEO_PLAYER_FEATURED_VIDEO_ON_INDEX_PAGE }}
+
+PRE_UPLOAD_MEDIA_MESSAGE = "{{ PRE_UPLOAD_MEDIA_MESSAGE }}"
+
+# email settings
+DEFAULT_FROM_EMAIL = "{{ DEFAULT_FROM_EMAIL }}"
+EMAIL_HOST_PASSWORD = "{{ EMAIL_HOST_PASSWORD }}"
+EMAIL_HOST_USER = "{{ EMAIL_HOST_USER }}"
+EMAIL_USE_TLS = {{ EMAIL_USE_TLS }}
+SERVER_EMAIL = "{{ SERVER_EMAIL }}"
+EMAIL_HOST = "{{ EMAIL_HOST }}"
+EMAIL_PORT = {{ EMAIL_PORT }}
+ADMIN_EMAIL_LIST = {{ ADMIN_EMAIL_LIST }}
+
+
+MEDIA_IS_REVIEWED = {{ MEDIA_IS_REVIEWED }}  # whether an admin needs to review a media file.
+# By default consider this is not needed.
+# If set to False, then each new media need be reviewed otherwise
+# it won't appear on public listings
+
+# if set to True the url for original file is returned to the API.
+SHOW_ORIGINAL_MEDIA = {{ SHOW_ORIGINAL_MEDIA }}
+# Keep in mind that nginx will serve the file unless there's
+# some authentication taking place. Check nginx file and setup a
+# basic http auth user/password if you want to restrict access
+
+MAX_MEDIA_PER_PLAYLIST = {{ MAX_MEDIA_PER_PLAYLIST }}
+# bytes, size of uploaded media
+UPLOAD_MAX_SIZE = {{ UPLOAD_MAX_SIZE }}
+
+MAX_CHARS_FOR_COMMENT = {{ MAX_CHARS_FOR_COMMENT }}  # so that it doesn't end up huge
+TIMESTAMP_IN_TIMEBAR = {{ TIMESTAMP_IN_TIMEBAR }}  # shows timestamped comments in the timebar for videos
+ALLOW_MENTION_IN_COMMENTS = {{ ALLOW_MENTION_IN_COMMENTS }}  # allowing to mention other users with @ in the comments
+
+# valid options: content, author
+RELATED_MEDIA_STRATEGY = "{{ RELATED_MEDIA_STRATEGY }}"
+
+USE_I18N = {{ USE_I18N }}
+USE_L10N = {{ USE_L10N }}
+USE_TZ = {{ USE_TZ }}
+SITE_ID = {{ SITE_ID }}
+
+# protection agains anonymous users
+# per ip address limit, for actions as like/dislike/report
+TIME_TO_ACTION_ANONYMOUS = {{ TIME_TO_ACTION_ANONYMOUS }}
+
+# django-allauth settings
+ACCOUNT_SESSION_REMEMBER = {{ ACCOUNT_SESSION_REMEMBER }}
+ACCOUNT_AUTHENTICATION_METHOD = "{{ ACCOUNT_AUTHENTICATION_METHOD }}"
+ACCOUNT_EMAIL_REQUIRED = {{ ACCOUNT_EMAIL_REQUIRED }}  # new users need to specify email
+ACCOUNT_EMAIL_VERIFICATION = "{{ ACCOUNT_EMAIL_VERIFICATION }}"  # 'mandatory' 'none'
+ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = {{ ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION }}
+ACCOUNT_USERNAME_MIN_LENGTH = "{{ ACCOUNT_USERNAME_MIN_LENGTH }}"
+ACCOUNT_ADAPTER = "users.adapter.MyAccountAdapter"
+ACCOUNT_SIGNUP_FORM_CLASS = "users.forms.SignupForm"
+ACCOUNT_USERNAME_VALIDATORS = "users.validators.custom_username_validators"
+ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE = {{ ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE }}
+ACCOUNT_USERNAME_REQUIRED = {{ ACCOUNT_USERNAME_REQUIRED }}
+ACCOUNT_LOGIN_ON_PASSWORD_RESET = {{ ACCOUNT_LOGIN_ON_PASSWORD_RESET }}
+ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = {{ ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS }}
+ACCOUNT_LOGIN_ATTEMPTS_LIMIT = {{ ACCOUNT_LOGIN_ATTEMPTS_LIMIT }}
+ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT = {{ ACCOUNT_LOGIN_ATTEMPTS_TIMEOUT }}
+# registration won't be open, might also consider to remove links for register
+USERS_CAN_SELF_REGISTER = {{ USERS_CAN_SELF_REGISTER }}
+
+RESTRICTED_DOMAINS_FOR_USER_REGISTRATION = {{ RESTRICTED_DOMAINS_FOR_USER_REGISTRATION }}
+
+# django rest settings
+REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.BasicAuthentication",
+        "rest_framework.authentication.TokenAuthentication",
+    ),
+    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
+    "PAGE_SIZE": 50,
+    "DEFAULT_PARSER_CLASSES": [
+        "rest_framework.parsers.JSONParser",
+    ],
+}
+
+
+SECRET_KEY = "{{ SECRET_KEY }}"
+# TODO: this needs to be changed!
+
+TEMP_DIRECTORY = "/tmp"  # Don't use a temp directory inside BASE_DIR!!!
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+STATIC_URL = "/static/"  # where js/css files are stored on the filesystem
+MEDIA_URL = "/media/"  # URL where static files are served from the server
+STATIC_ROOT = BASE_DIR + "/static/"
+# where uploaded + encoded media are stored
+MEDIA_ROOT = BASE_DIR + "/media_files/"
+
+# these used to be os.path.join(MEDIA_ROOT, "folder/") but update to
+# Django 3.1.9 requires not absolute paths to be utilized...
+
+MEDIA_UPLOAD_DIR = "original/"
+MEDIA_ENCODING_DIR = "encoded/"
+THUMBNAIL_UPLOAD_DIR = f"{MEDIA_UPLOAD_DIR}/thumbnails/"
+SUBTITLES_UPLOAD_DIR = f"{MEDIA_UPLOAD_DIR}/subtitles/"
+HLS_DIR = os.path.join(MEDIA_ROOT, "hls/")
+
+FFMPEG_COMMAND = "ffmpeg"  # this is the path
+FFPROBE_COMMAND = "ffprobe"  # this is the path
+MP4HLS = "mp4hls"
+
+MASK_IPS_FOR_ACTIONS = {{ MASK_IPS_FOR_ACTIONS }}
+# how many seconds a process in running state without reporting progress is
+# considered as stale...unfortunately v9 seems to not include time
+# some times so raising this high
+RUNNING_STATE_STALE = {{ RUNNING_STATE_STALE }}
+
+FRIENDLY_TOKEN_LEN = {{ FRIENDLY_TOKEN_LEN }}
+
+# for videos, after that duration get split into chunks
+# and encoded independently
+CHUNKIZE_VIDEO_DURATION = {{ CHUNKIZE_VIDEO_DURATION }}
+# aparently this has to be smaller than VIDEO_CHUNKIZE_DURATION
+VIDEO_CHUNKS_DURATION = {{ VIDEO_CHUNKS_DURATION }}
+
+# always get these two, even if upscaling
+MINIMUM_RESOLUTIONS_TO_ENCODE = {{ MINIMUM_RESOLUTIONS_TO_ENCODE }}
+
+# default settings for notifications
+# not all of them are implemented
+
+USERS_NOTIFICATIONS = {
+    "MEDIA_ADDED": True,  # in use
+    "MEDIA_ENCODED": False,  # not implemented
+    "MEDIA_REPORTED": True,  # in use
+}
+
+ADMINS_NOTIFICATIONS = {
+    "NEW_USER": True,  # in use
+    "MEDIA_ADDED": True,  # in use
+    "MEDIA_ENCODED": False,  # not implemented
+    "MEDIA_REPORTED": True,  # in use
+}
+
+
+# this is for fineuploader - media uploads
+UPLOAD_DIR = "uploads/"
+CHUNKS_DIR = "chunks/"
+
+# number of files to upload using fineuploader at once
+UPLOAD_MAX_FILES_NUMBER = 100
+CONCURRENT_UPLOADS = True
+CHUNKS_DONE_PARAM_NAME = "done"
+FILE_STORAGE = "django.core.files.storage.DefaultStorage"
+
+X_FRAME_OPTIONS = "ALLOWALL"
+EMAIL_BACKEND = "djcelery_email.backends.CeleryEmailBackend"
+CELERY_EMAIL_TASK_CONFIG = {
+    "queue": "short_tasks",
+}
+
+POST_UPLOAD_AUTHOR_MESSAGE_UNLISTED_NO_COMMENTARY = ""
+# a message to be shown on the author of a media file and only
+# only in case where unlisted workflow is used and no commentary
+# exists
+
+CANNOT_ADD_MEDIA_MESSAGE = ""
+
+# mp4hls command, part of Bendo4
+MP4HLS_COMMAND = "/home/mediacms.io/mediacms/Bento4-SDK-1-6-0-637.x86_64-unknown-linux/bin/mp4hls"
+
+# highly experimental, related with remote workers
+ADMIN_TOKEN = "c2b8e1838b6128asd333ddc5e24"
+# this is used by remote workers to push
+# encodings once they are done
+# USE_BASIC_HTTP = True
+# BASIC_HTTP_USER_PAIR = ('user', 'password')
+# specify basic auth user/password pair for use with the
+# remote workers, if nginx basic auth is setup
+# apache2-utils need be installed
+# then run
+# htpasswd -c /home/mediacms.io/mediacms/deploy/.htpasswd user
+# and set a password
+# edit /etc/nginx/sites-enabled/mediacms.io and
+# uncomment the two lines related to htpasswd
+
+
+CKEDITOR_CONFIGS = {
+    "default": {
+        "toolbar": "Custom",
+        "width": "100%",
+        "toolbar_Custom": [
+            ["Styles"],
+            ["Format"],
+            ["Bold", "Italic", "Underline"],
+            ["HorizontalRule"],
+            [
+                "NumberedList",
+                "BulletedList",
+                "-",
+                "Outdent",
+                "Indent",
+                "-",
+                "JustifyLeft",
+                "JustifyCenter",
+                "JustifyRight",
+                "JustifyBlock",
+            ],
+            ["Link", "Unlink"],
+            ["Image"],
+            ["RemoveFormat", "Source"],
+        ],
+    }
+}
+
+
+AUTH_USER_MODEL = "users.User"
+LOGIN_REDIRECT_URL = "/"
+
+AUTHENTICATION_BACKENDS = (
+    "django.contrib.auth.backends.ModelBackend",
+    "allauth.account.auth_backends.AuthenticationBackend",
+)
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "allauth",
+    "allauth.account",
+    "allauth.socialaccount",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "django.contrib.sites",
+    "rest_framework",
+    "rest_framework.authtoken",
+    "imagekit",
+    "files.apps.FilesConfig",
+    "users.apps.UsersConfig",
+    "actions.apps.ActionsConfig",
+    "debug_toolbar",
+    "mptt",
+    "crispy_forms",
+    "uploader.apps.UploaderConfig",
+    "djcelery_email",
+    "ckeditor",
+    "drf_yasg",
+]
+
+MIDDLEWARE = [
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
+]
+
+ROOT_URLCONF = "cms.urls"
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": ["templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.template.context_processors.media",
+                "django.contrib.messages.context_processors.messages",
+                "files.context_processors.stuff",
+            ],
+        },
+    },
+]
+
+WSGI_APPLICATION = "cms.wsgi.application"
+
+AUTH_PASSWORD_VALIDATORS = [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "OPTIONS": {
+            "min_length": 5,
+        },
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+]
+
+FILE_UPLOAD_HANDLERS = [
+    "django.core.files.uploadhandler.TemporaryFileUploadHandler",
+]
+
+LOGS_DIR = os.path.join(BASE_DIR, "logs")
+
+error_filename = os.path.join(LOGS_DIR, "debug.log")
+if not os.path.exists(LOGS_DIR):
+    try:
+        os.mkdir(LOGS_DIR)
+    except PermissionError:
+        pass
+
+if not os.path.isfile(error_filename):
+    open(error_filename, 'a').close()
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        "file": {
+            "level": "ERROR",
+            "class": "logging.FileHandler",
+            "filename": error_filename,
+        },
+    },
+    "loggers": {
+        "django": {
+            "handlers": ["file"],
+            "level": "ERROR",
+            "propagate": True,
+        },
+    },
+}
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": "{{ POSTGRESQL_DATABASE }}",
+        "HOST": "{{ POSTGRESQL_IP }}",
+        "PORT": "5432",
+        "USER": "{{ POSTGRESQL_USER }}",
+        "PASSWORD": "{{ POSTGRESQL_PASSWD }}",
+    }
+}
+
+
+REDIS_LOCATION = "redis://{{ REDIS_IP }}:6379/1"
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": REDIS_LOCATION,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+        },
+    }
+}
+
+SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+SESSION_CACHE_ALIAS = "default"
+
+# CELERY STUFF
+BROKER_URL = REDIS_LOCATION
+CELERY_RESULT_BACKEND = BROKER_URL
+CELERY_ACCEPT_CONTENT = ["application/json"]
+CELERY_TASK_SERIALIZER = "json"
+CELERY_RESULT_SERIALIZER = "json"
+CELERY_TIMEZONE = TIME_ZONE
+CELERY_SOFT_TIME_LIMIT = 2 * 60 * 60
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1
+CELERYD_PREFETCH_MULTIPLIER = 1
+
+CELERY_BEAT_SCHEDULE = {
+    # clear expired sessions, every sunday 1.01am. By default Django has 2week
+    # expire date
+    "clear_sessions": {
+        "task": "clear_sessions",
+        "schedule": crontab(hour=1, minute=1, day_of_week=6),
+    },
+    "get_list_of_popular_media": {
+        "task": "get_list_of_popular_media",
+        "schedule": crontab(minute=1, hour="*/10"),
+    },
+    "update_listings_thumbnails": {
+        "task": "update_listings_thumbnails",
+        "schedule": crontab(minute=2, hour="*/30"),
+    },
+}
+# TODO: beat, delete chunks from media root
+# chunks_dir after xx days...(also uploads_dir)
+
+
+LOCAL_INSTALL = {{ LOCAL_INSTALL }}
+
+# this is an option to make the whole portal available to logged in users only
+# it is placed here so it can be overrided on local_settings.py
+GLOBAL_LOGIN_REQUIRED = {{ GLOBAL_LOGIN_REQUIRED }}
+
+# TODO: separate settings on production/development more properly, for now
+# this should be ok
+CELERY_TASK_ALWAYS_EAGER = False
+if os.environ.get("TESTING"):
+    CELERY_TASK_ALWAYS_EAGER = True
+
+
+try:
+    # keep a local_settings.py file for local overrides
+    from .local_settings import *  # noqa
+
+    # ALLOWED_HOSTS needs a url/ip
+    ALLOWED_HOSTS.append(FRONTEND_HOST.replace("http://", "").replace("https://", ""))
+except ImportError:
+    # local_settings not in use
+    pass
+
+
+if "http" not in FRONTEND_HOST:
+    # FRONTEND_HOST needs a http:// preffix
+    FRONTEND_HOST = f"http://{FRONTEND_HOST}"
+
+if LOCAL_INSTALL:
+    SSL_FRONTEND_HOST = FRONTEND_HOST.replace("http", "https")
+else:
+    SSL_FRONTEND_HOST = FRONTEND_HOST
+
+if GLOBAL_LOGIN_REQUIRED:
+    # this should go after the AuthenticationMiddleware middleware
+    MIDDLEWARE.insert(5, "login_required.middleware.LoginRequiredMiddleware")
+    LOGIN_REQUIRED_IGNORE_PATHS = [
+        r'/accounts/login/$',
+        r'/accounts/logout/$',
+        r'/accounts/signup/$',
+        r'/api/v[0-9]+/',
+    ]


### PR DESCRIPTION
## Description
<!-- Describe the changes introduced by this PR for the reviewers to fully understand. -->
This PR implements ansible playbook for deploying mediacms on remote hosts, as an alternative to install.sh script.

PR Description:

1. A directory called "ansible" has been created in the root of the repository.
2. No other additional changes have been made outside of the "ansible" directory
3. In the "ansible" directory the starting point of the application is the "hosts" file, which is where the different deploy hosts are declared.

hosts file operation:

- in the hosts file, 3 groups can be declared: **mediacms_servers**, **postgresql_servers** and **redis_servers**.
- **postgresql_servers** group: one host can be declared, In this case, postgres installation will not be performed on the mediacms server. In case there are more than one, only the first one will be selected. If the **postgresql_servers** group is not declared, the installation will be performed on localhost and the behavior is the same as install.sh. Only Debian bullseye postgresql server allowed for remote hosts (This is due to the presence of the postgres system user, by default in this distro, which is used to create the database user and migrations). Remote postgresql servers must have python3-psycopg2 package installed and listen on default port 5432.  playbooks does not take care of installation on remote postgres servers. the playbook takes care of configuring DATABASES appropriately in settings.py, independent if it is on localhost on remote host.

- **mediacms_servers** group: only one host can be declared. In case more than one are added, redis_servers must not be declared, this is because there would be collisions in the celery queues.
-  **redis_servers** group: only one host can be declared, in case the redis_servers group is not added, the installation of redis-server will be done on localhost, equal to install.sh.

In short, hosts file should be declared as:

```
[mediacms_servers]
testmediacms1 ansible_port=22

[postgresql_servers]
postgresql ansible_port=22

[redis_servers]
redis ansible_port=22
```

with this it is possible to separate redis, postgres and mediacms.

or:
```
[mediacms_servers]
testmediacms1 ansible_port=22
```
in this way the same installation is produced as in install.sh

Assuming you are located inside the ansible directory, and you have edited the hosts file,  and have ansible installed on your computer, and you have ssh access to the remote machines mediacms... etc. mediacms is installed on the remote machine by running:

`ansible-playbook playbooks/01_system_deploy.yml`

Regards.
