### PR TITLE
Allow password reset & email verify pages on global login required

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -481,5 +481,7 @@ if GLOBAL_LOGIN_REQUIRED:
         r'/accounts/login/$',
         r'/accounts/logout/$',
         r'/accounts/signup/$',
+        r'/accounts/password/.*/$',
+        r'/accounts/confirm-email/.*/$',
         r'/api/v[0-9]+/',
     ]


### PR DESCRIPTION
This PR adds the password/confirm-email to the whitelisted pages for when global login is required. The matching allows subpages of those pages to be whitelisted as well, such as /accounts/password/reset/ or /accounts/password/change/, as well as the tokens used in the email confirmation system.

This fixes email verification as well as password resets when global login is required

Properly fixes #770