### PR TITLE
Add CAPTCHA to Contact form

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -299,6 +299,7 @@ INSTALLED_APPS = [
     "djcelery_email",
     "ckeditor",
     "drf_yasg",
+    "captcha",
 ]
 
 MIDDLEWARE = [

--- a/cms/urls.py
+++ b/cms/urls.py
@@ -28,4 +28,5 @@ urlpatterns = [
     re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path('docs/api/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+    path('captcha/', include('captcha.urls')),
 ]

--- a/files/forms.py
+++ b/files/forms.py
@@ -1,5 +1,5 @@
-from django import forms
 from captcha.fields import CaptchaField
+from django import forms
 
 from .methods import get_next_state, is_mediacms_editor
 from .models import Media, Subtitle

--- a/files/forms.py
+++ b/files/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from captcha.fields import CaptchaField
 
 from .methods import get_next_state, is_mediacms_editor
 from .models import Media, Subtitle
@@ -79,6 +80,7 @@ class ContactForm(forms.Form):
     from_email = forms.EmailField(required=True)
     name = forms.CharField(required=False)
     message = forms.CharField(widget=forms.Textarea, required=True)
+    captcha = CaptchaField()
 
     def __init__(self, user, *args, **kwargs):
         super(ContactForm, self).__init__(*args, **kwargs)

--- a/files/views.py
+++ b/files/views.py
@@ -147,6 +147,8 @@ Sender email: %s\n
             email.send(fail_silently=True)
             success_msg = "Message was sent! Thanks for contacting"
             context["success_msg"] = success_msg
+        else:
+            context["success_msg"] = "The information you entered was invalid.  Please click Back and try again."
 
     return render(request, "cms/contact.html", context)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ m3u8==3.5.0
 django-ckeditor==6.6.1
 django-debug-toolbar==4.1.0
 django-login-required-middleware==0.9.0
+django-simple-captcha==0.5.18


### PR DESCRIPTION
## Description
One of my installs receives a lot of spam through the Contact form.  This adds a CAPTCHA to the Contact form to protect against spam.


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*
(EDIT) If upgrading an existing installation, make sure to run `pip install -r requirements.txt` to install the CAPTCHA module.

Per the documentation at:

https://django-simple-captcha.readthedocs.io/en/latest/usage.html#adding-to-a-form

You *have* to run `python manage.py migrate` for this to work.  It adds information to the database that the CAPTCHA plugin requires.  Without it, the form will not work.  But this is standard procedure for MediaCMS version upgrades anyway so I don't see it as a major issue.

*Post-deploy*

