### PR TITLE
Add admin action to generate missing encodings for a particular Media

### DIFF
--- a/files/admin.py
+++ b/files/admin.py
@@ -40,6 +40,12 @@ class MediaAdmin(admin.ModelAdmin):
     def get_comments_count(self, obj):
         return obj.comments.count()
 
+    @admin.action(description="Generate missing encoding(s)", permissions=["change"])
+    def generate_missing_encodings(modeladmin, request, queryset):
+        for m in queryset:
+            m.encode()
+
+    actions = [generate_missing_encodings]
     get_comments_count.short_description = "Comments count"
 
 

--- a/files/admin.py
+++ b/files/admin.py
@@ -43,7 +43,7 @@ class MediaAdmin(admin.ModelAdmin):
     @admin.action(description="Generate missing encoding(s)", permissions=["change"])
     def generate_missing_encodings(modeladmin, request, queryset):
         for m in queryset:
-            m.encode()
+            m.encode(force=False)
 
     actions = [generate_missing_encodings]
     get_comments_count.short_description = "Comments count"


### PR DESCRIPTION
## Description
<!-- Describe the changes introduced by this PR for the reviewers to fully understand. -->
This adds an action to the MediaCMS Administration section to allow you to select Media items and generate missing encodings.  That way, if for some reason an encoding fails or if you enable other encoding profiles (such as enabling VP9 profiles after a video is posted), you can reprocess the media to fill in the gaps.

Fixes #874


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

(EDIT) Typo