### PR TITLE
Add useful fields to the Encodings admin screen

### DIFF
--- a/files/admin.py
+++ b/files/admin.py
@@ -74,7 +74,18 @@ class SubtitleAdmin(admin.ModelAdmin):
 
 
 class EncodingAdmin(admin.ModelAdmin):
-    pass
+    list_display = ["get_title", "chunk", "profile", "progress", "status", "has_file"]
+    list_filter = ["chunk", "profile", "status"]
+
+    def get_title(self, obj):
+        return str(obj)
+
+    get_title.short_description = "Encoding"
+
+    def has_file(self, obj):
+        return obj.media_encoding_url is not None
+
+    has_file.short_description = "Has file"
 
 
 admin.site.register(EncodeProfile, EncodeProfileAdmin)


### PR DESCRIPTION
## Description
<!-- Describe the changes introduced by this PR for the reviewers to fully understand. -->
When looking at the admin screen for Encodings, there is almost no information presented until you click on a particular encoding.  This adds a few useful fields to that screen as additional columns and filters.

## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

