### PR TITLE
Add configuration to set how many threads each ffmpeg process can use

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -160,6 +160,7 @@ HLS_DIR = os.path.join(MEDIA_ROOT, "hls/")
 
 FFMPEG_COMMAND = "ffmpeg"  # this is the path
 FFPROBE_COMMAND = "ffprobe"  # this is the path
+FFMPEG_THREADS = 0  # default - use optimal number of threads
 MP4HLS = "mp4hls"
 
 MASK_IPS_FOR_ACTIONS = True

--- a/files/helpers.py
+++ b/files/helpers.py
@@ -554,6 +554,8 @@ def get_base_ffmpeg_command(
 
     base_cmd = [
         settings.FFMPEG_COMMAND,
+        "-threads",
+        str(settings.FFMPEG_THREADS),
         "-y",
         "-i",
         input_file,

--- a/files/models.py
+++ b/files/models.py
@@ -1482,6 +1482,8 @@ def encoding_file_save(sender, instance, created, **kwargs):
                             ff.write("file {}\n".format(f))
                     cmd = [
                         settings.FFMPEG_COMMAND,
+                        "-threads",
+                        str(settings.FFMPEG_THREADS),
                         "-y",
                         "-f",
                         "concat",

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -62,6 +62,8 @@ def chunkize_media(self, friendly_token, profiles, force=True):
     chunks_file_name += ".mkv"
     cmd = [
         settings.FFMPEG_COMMAND,
+        "-threads",
+        str(settings.FFMPEG_THREADS),
         "-y",
         "-i",
         media.media_file.path,

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -235,6 +235,8 @@ def encode_media(
         # -ss 5 start from 5 second. -t 25 until 25 sec
         command = [
             settings.FFMPEG_COMMAND,
+            "-threads",
+            str(settings.FFMPEG_THREADS),
             "-y",
             "-ss",
             "3",


### PR DESCRIPTION
## Description
<!-- Describe the changes introduced by this PR for the reviewers to fully understand. -->
I was running into issues where, while transcoding, a single server would get a load average of over 4x the number of cores it had.  This turned out to be a combination of Celery running as many tasks concurrently as it could and each ffmpeg process using all cores.  This would result in a ton of chunks' transcoding processes competing for CPU, which would cause them to time out.  This change allows you to at least limit the number of threads that ffmpeg can use concurrently so you can actually tune transcoding CPU usage properly.

## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

