### PR TITLE
Fix bug that crashes page if an encoding has a null URL

### DIFF
--- a/frontend/src/static/js/components/media-actions/VideoMediaDownloadLink.jsx
+++ b/frontend/src/static/js/components/media-actions/VideoMediaDownloadLink.jsx
@@ -19,7 +19,7 @@ function downloadOptionsList() {
       if (Object.keys(encodings_info[k]).length) {
         for (g in encodings_info[k]) {
           if (encodings_info[k].hasOwnProperty(g)) {
-            if ('success' === encodings_info[k][g].status && 100 === encodings_info[k][g].progress) {
+            if ('success' === encodings_info[k][g].status && 100 === encodings_info[k][g].progress && null !== encodings_info[k][g].url) {
               optionsList[encodings_info[k][g].title] = {
                 text: k + ' - ' + g.toUpperCase() + ' (' + encodings_info[k][g].size + ')',
                 link: formatInnerLink(encodings_info[k][g].url, SiteContext._currentValue.url),


### PR DESCRIPTION
## Description
Fixes #882, which I'm now seeing on a nearly daily basis.


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

