### PR TITLE
Add a workaround for the start time race condition in Video.js

### DIFF
--- a/frontend/src/static/js/components/video-player/VideoPlayer.jsx
+++ b/frontend/src/static/js/components/video-player/VideoPlayer.jsx
@@ -197,6 +197,8 @@ export function VideoPlayer(props) {
       const paramT = Number(urlParams.get('t'));
       const timestamp = !isNaN(paramT) ? paramT : 0;
       player.player.currentTime(timestamp);
+      // This is a really hacky way to work around a race condition within Video.js where it thinks it was ready in currentTime() but it actually wasn't so it clears this value:
+      player.player.cache_.initTime = timestamp;
     });
 
     return () => {


### PR DESCRIPTION
## Description
Turns out the timestamp problem is due to a race condition within Video.js.  Since we can't really fix that without breaking the ability to update Video.js in the future, this adds a workaround for the race condition so that linking to a particular time in a video works.

Fixes #926

See also https://github.com/mediacms-io/mediacms/discussions/319


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

