### PR TITLE
Only finalize an encoding when all chunks have finished

### DIFF
--- a/files/models.py
+++ b/files/models.py
@@ -1478,7 +1478,7 @@ def encoding_file_save(sender, instance, created, **kwargs):
                     break
 
             for chunk in chunks:
-                if not (chunk.media_file and chunk.media_file.path):
+                if not (chunk.media_file and chunk.media_file.path) or chunk.status != "success":
                     complete = False
                     break
 


### PR DESCRIPTION
## Description
Make sure that all chunks are done before kicking off HLS creation.  Fixes #929


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

