### PR TITLE
Calculate md5sum on uploads while in /tmp, deduplicate code

### DIFF
--- a/files/helpers.py
+++ b/files/helpers.py
@@ -270,13 +270,6 @@ def media_file_info(input_file):
         ret["fail"] = True
         return ret
 
-    cmd = ["md5sum", input_file]
-    stdout = run_command(cmd).get("out")
-    if stdout:
-        md5sum = stdout.split()[0]
-    else:
-        md5sum = ""
-
     cmd = [
         settings.FFPROBE_COMMAND,
         "-loglevel",
@@ -460,8 +453,19 @@ def media_file_info(input_file):
     ret["video_info"] = video_info
     ret["audio_info"] = audio_info
     ret["is_video"] = True
-    ret["md5sum"] = md5sum
     return ret
+
+
+def media_file_md5sum(input_file):
+    """
+    Get the md5sum of a file
+    """
+    cmd = ["md5sum", input_file]
+    stdout = run_command(cmd).get("out")
+    if stdout:
+        return stdout.split()[0]
+    else:
+        return ""
 
 
 def calculate_seconds(duration):

--- a/files/models.py
+++ b/files/models.py
@@ -465,7 +465,8 @@ class Media(models.Model):
                     self.media_info = json.dumps(ret)
                 except TypeError:
                     self.media_info = ""
-                self.md5sum = ret.get("md5sum")
+                if not self.md5sum:
+                    self.md5sum = helpers.media_file_md5sum(self.media_file.path)
                 self.size = helpers.show_file_size(ret.get("file_size"))
             else:
                 self.media_type = ""
@@ -1123,11 +1124,7 @@ class Encoding(models.Model):
                 size = int(stdout.strip())
                 self.size = helpers.show_file_size(size)
         if self.chunk_file_path and not self.md5sum:
-            cmd = ["md5sum", self.chunk_file_path]
-            stdout = helpers.run_command(cmd).get("out")
-            if stdout:
-                md5sum = stdout.strip().split()[0]
-                self.md5sum = md5sum
+            self.md5sum = helpers.media_file_md5sum(self.chunk_file_path)
 
         super(Encoding, self).save(*args, **kwargs)
 

--- a/files/tasks.py
+++ b/files/tasks.py
@@ -29,6 +29,7 @@ from .helpers import (
     get_file_name,
     get_file_type,
     media_file_info,
+    media_file_md5sum,
     produce_ffmpeg_commands,
     produce_friendly_token,
     rm_file,
@@ -99,10 +100,7 @@ def chunkize_media(self, friendly_token, profiles, force=True):
     chunks_dict = {}
     # calculate once md5sums
     for chunk in chunks:
-        cmd = ["md5sum", chunk]
-        stdout = run_command(cmd).get("out")
-        md5sum = stdout.strip().split()[0]
-        chunks_dict[chunk] = md5sum
+        chunks_dict[chunk] = media_file_md5sum(chunk)
 
     for profile in profiles:
         if media.video_height and media.video_height < profile.resolution:


### PR DESCRIPTION
## Description
Fixes #937 

Also deduplicates the code for calculating md5sums, since that was being done separately in multiple places in the code


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

