### PR TITLE
Fix commenting by regular users when posting media requires advanced permissions

### DIFF
--- a/cms/permissions.py
+++ b/cms/permissions.py
@@ -11,6 +11,13 @@ class IsAuthorizedToAdd(permissions.BasePermission):
         return user_allowed_to_upload(request)
 
 
+class IsAuthorizedToAddComment(permissions.BasePermission):
+    def has_permission(self, request, view):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        return user_allowed_to_comment(request)
+
+
 class IsUserOrManager(permissions.BasePermission):
     """To be used in cases where request.user is either the
     object owner, or anyone amongst MediaCMS managers
@@ -63,6 +70,27 @@ def user_allowed_to_upload(request):
         if request.user.email_is_verified:
             return True
     elif settings.CAN_ADD_MEDIA == "advancedUser":
+        if request.user.advancedUser:
+            return True
+    return False
+
+
+def user_allowed_to_comment(request):
+    """Any custom logic for whether a user is allowed
+    to comment lives here
+    """
+    if request.user.is_anonymous:
+        return False
+    if request.user.is_superuser:
+        return True
+
+    # Default is "all"
+    if not hasattr(settings, "CAN_COMMENT") or settings.CAN_COMMENT == "all":
+        return True
+    elif settings.CAN_COMMENT == "email_verified":
+        if request.user.email_is_verified:
+            return True
+    elif settings.CAN_COMMENT == "advancedUser":
         if request.user.advancedUser:
             return True
     return False

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -15,6 +15,10 @@ TIME_ZONE = "Europe/London"
 # valid options include 'all', 'email_verified', 'advancedUser'
 CAN_ADD_MEDIA = "all"
 
+# who can comment
+# valid options include 'all', 'email_verified', 'advancedUser'
+CAN_COMMENT = "all"
+
 # valid choices here are 'public', 'private', 'unlisted
 PORTAL_WORKFLOW = "public"
 

--- a/files/views.py
+++ b/files/views.py
@@ -24,7 +24,12 @@ from rest_framework.views import APIView
 
 from actions.models import USER_MEDIA_ACTIONS, MediaAction
 from cms.custom_pagination import FastPaginationWithoutCount
-from cms.permissions import IsAuthorizedToAdd, IsUserOrEditor, user_allowed_to_upload
+from cms.permissions import (
+    IsAuthorizedToAdd,
+    IsAuthorizedToAddComment,
+    IsUserOrEditor,
+    user_allowed_to_upload,
+)
 from users.models import User
 
 from .forms import ContactForm, MediaForm, SubtitleForm
@@ -1203,7 +1208,7 @@ class CommentDetail(APIView):
     Delete comment (DELETE)
     """
 
-    permission_classes = (IsAuthorizedToAdd,)
+    permission_classes = (IsAuthorizedToAddComment,)
     parser_classes = (JSONParser, MultiPartParser, FormParser, FileUploadParser)
 
     def get_object(self, friendly_token):


### PR DESCRIPTION
Fixes #216 

## Description
This allows the site operator control over who is able to comment.  It is configured by default to allow all logged-in users to be able to comment, but can be changed to only allow email_verified users or advanced users to comment.  This also fixes #216 since it separates out the comment permissions from the media posting permissions.

It does not, however, add anonymous commenting as was mentioned in passing at the end of #216.  That change is a little more difficult and outside of the scope of what I could quickly accomplish.


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

