### PR TITLE
fix #943

### DIFF
--- a/deploy/docker/entrypoint.sh
+++ b/deploy/docker/entrypoint.sh
@@ -28,7 +28,8 @@ else
 fi
 
 # We should do this only for folders that have a different owner, since it is an expensive operation
-find /home/mediacms.io/ ! \( -user www-data -group $TARGET_GID \) -exec chown www-data:$TARGET_GID {} +
+# Also ignoring .git folder to fix this issue https://github.com/mediacms-io/mediacms/issues/934
+find /home/mediacms.io/ ! \( -path "*.git*" \) -and ! \( -user www-data -group $TARGET_GID \) -exec chown www-data:$TARGET_GID {} +
 
 chmod +x /home/mediacms.io/mediacms/deploy/docker/start.sh /home/mediacms.io/mediacms/deploy/docker/prestart.sh
 


### PR DESCRIPTION
## Description
Fixes issue #943 and other issues related to chown bug while running the containers on macos.

Updated the `deploy/docker/entrypoint.sh` file to ignore the `.git` directory mounted by the volume into the application's root dir. This avoids the permission errors mentioned in several issues. 

This is the new command.
```bash
find /home/mediacms.io/ ! \( -path "*.git*" \) -and ! \( -user www-data -group $TARGET_GID \) -exec chown www-data:$TARGET_GID {} +
```


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*
N/A
*Post-deploy*
N/A
