### PR TITLE
Update insert login_required middleware position to allow auth middleware to load first

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -484,7 +484,7 @@ else:
 
 if GLOBAL_LOGIN_REQUIRED:
     # this should go after the AuthenticationMiddleware middleware
-    MIDDLEWARE.insert(5, "login_required.middleware.LoginRequiredMiddleware")
+    MIDDLEWARE.insert(6, "login_required.middleware.LoginRequiredMiddleware")
     LOGIN_REQUIRED_IGNORE_PATHS = [
         r'/accounts/login/$',
         r'/accounts/logout/$',


### PR DESCRIPTION
## Description
<!-- Describe the changes introduced by this PR for the reviewers to fully understand. -->

This PR fixes #1081 by ensuring that the login_required middleware is loaded after the authentication middleware. This is after a new middleware was added in 4992cc425c72664ff460cc376c388938c2a8731c at https://github.com/mediacms-io/mediacms/blame/main/cms/settings.py#L314. 

## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*
NONE

*Post-deploy*
NONE