### PR TITLE
Allow embedding by list of trusted referers when GLOBAL_LOGIN is enabled.

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -134,6 +134,7 @@ RESTRICTED_DOMAINS_FOR_USER_REGISTRATION = ["xxx.com", "emaildomainwhatever.com"
 # Empty list disables.
 ALLOWED_DOMAINS_FOR_USER_REGISTRATION = []   
 
+
 # django rest settings
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": (
@@ -459,6 +460,12 @@ LOCAL_INSTALL = False
 # it is placed here so it can be overrided on local_settings.py
 GLOBAL_LOGIN_REQUIRED = False
 
+# When GLOBAL_LOGIN_REQUIRED is True, allow certain domains to embed the content.
+# This is useful when you want to serve content on your servers but not allow general public access.
+# You also must properly configure CORS origins for this to work.
+# Should be a comma-separated list of domains.
+GLOBAL_LOGIN_ALLOW_EMBED_DOMAINS = [] # ['my-refering-domain.com', 'cdn.my-site.com']
+
 # TODO: separate settings on production/development more properly, for now
 # this should be ok
 CELERY_TASK_ALWAYS_EAGER = False
@@ -497,6 +504,11 @@ if GLOBAL_LOGIN_REQUIRED:
         r'/accounts/confirm-email/.*/$',
         r'/api/v[0-9]+/',
     ]
+    if (GLOBAL_LOGIN_ALLOW_EMBED_DOMAINS):
+        LOGIN_REQUIRED_IGNORE_PATHS += [
+            r'^/embed.*', #r'/embed\?m=.*$',
+            r'^/media/.*'
+        ]
 
 # if True, only show original, don't perform any action on videos
 DO_NOT_TRANSCODE_VIDEO = False

--- a/cms/settings.py
+++ b/cms/settings.py
@@ -132,7 +132,7 @@ RESTRICTED_DOMAINS_FOR_USER_REGISTRATION = ["xxx.com", "emaildomainwhatever.com"
 
 # Comma separated list of domains:  ["organization.com", "private.organization.com", "org2.com"]
 # Empty list disables.
-ALLOWED_DOMAINS_FOR_USER_REGISTRATION = []   
+ALLOWED_DOMAINS_FOR_USER_REGISTRATION = []
 
 
 # django rest settings
@@ -464,7 +464,7 @@ GLOBAL_LOGIN_REQUIRED = False
 # This is useful when you want to serve content on your servers but not allow general public access.
 # You also must properly configure CORS origins for this to work.
 # Should be a comma-separated list of domains.
-GLOBAL_LOGIN_ALLOW_EMBED_DOMAINS = [] # ['my-refering-domain.com', 'cdn.my-site.com']
+GLOBAL_LOGIN_ALLOW_EMBED_DOMAINS = []  # ['my-refering-domain.com', 'cdn.my-site.com']
 
 # TODO: separate settings on production/development more properly, for now
 # this should be ok
@@ -506,7 +506,7 @@ if GLOBAL_LOGIN_REQUIRED:
     ]
     if (GLOBAL_LOGIN_ALLOW_EMBED_DOMAINS):
         LOGIN_REQUIRED_IGNORE_PATHS += [
-            r'^/embed.*', #r'/embed\?m=.*$',
+            r'^/embed.*',  # r'/embed\?m=.*$',
             r'^/media/.*'
         ]
 

--- a/docs/admins_docs.md
+++ b/docs/admins_docs.md
@@ -481,6 +481,7 @@ ADMINS_NOTIFICATIONS = {
 
 - Make the portal workflow public, but at the same time set `GLOBAL_LOGIN_REQUIRED = True` so that only logged in users can see content.
 - You can either set `REGISTER_ALLOWED = False` if you want to add members yourself or checkout options on "django-allauth settings" that affects registration in `cms/settings.py`. Eg set the portal invite only, or set email confirmation as mandatory, so that you control who registers.
+- If you wish to have private media management, but allow trusted referers to embed the media for viewing, you can over-ride the global login requirement for embedded media on some sites by setting `GLOBAL_LOGIN_ALLOW_EMBED_DOMAINS = ['your-approved-domain.com', ...]`.   This has the effect of checking the HTTP_REFERER domain in the request against the list of approved referers, and allowing the video to stream if there is a match.   The videos you wish to embed must be set to unlisted or public in the media management, and the referring site or proxy must properly set the HTTP_REFERER header to an approved domain. You may also need to properly set or update CORS_ALLOWED_ORIGINS headers depending on your specific configuration and cross-site requirements.   Depending on your use-case, you may need to patch the default player auto-play and share links to get a suitable plain-jane video feed.
 
 ### 5.24 Enable the sitemap
 

--- a/files/frontend_translations/__init__.py
+++ b/files/frontend_translations/__init__.py
@@ -32,7 +32,6 @@ for translation_file in files:
     replacement_strings[language_code] = tr_module.replacement_strings
 
 
-
 def get_translation(language_code):
     # get list of translations per language
     if not check_language_code(language_code):

--- a/files/management/commands/process_translations.py
+++ b/files/management/commands/process_translations.py
@@ -44,12 +44,12 @@ class Command(BaseCommand):
             with open(file_path, 'w') as f:
                 f.write("translation_strings = {\n")
                 for key, value in translation_strings_wip.items():
-                    f.write(f'    "{key}": "{value}",\n')
+                    f.write(f'    "{key}": "{value}", \n')
                 f.write("}\n\n")
 
                 f.write("replacement_strings = {\n")
                 for key, value in replacement_strings_wip.items():
-                    f.write(f'    "{key}": "{value}",\n')
+                    f.write(f'    "{key}": "{value}", \n')
                 f.write("}\n")
 
             self.stdout.write(self.style.SUCCESS(f'Processed {file}'))

--- a/files/views.py
+++ b/files/views.py
@@ -219,7 +219,7 @@ def embed_media(request):
 
     except PermissionDenied:
         return render(request, "cms/embed-403.html")
-        
+
     context = {}
     context["media"] = friendly_token
     return render(request, "cms/embed.html", context)

--- a/files/views.py
+++ b/files/views.py
@@ -209,10 +209,7 @@ def embed_media(request):
         return HttpResponseRedirect("/")
 
     try:
-        if (settings.GLOBAL_LOGIN_REQUIRED and
-            hasattr(settings,'GLOBAL_LOGIN_ALLOW_EMBED_DOMAINS') and
-            settings.GLOBAL_LOGIN_ALLOW_EMBED_DOMAINS):
-
+        if (settings.GLOBAL_LOGIN_REQUIRED and hasattr(settings, 'GLOBAL_LOGIN_ALLOW_EMBED_DOMAINS') and settings.GLOBAL_LOGIN_ALLOW_EMBED_DOMAINS):
             if request.META.get('HTTP_REFERER'):
                 referring_domain = urlparse(request.META['HTTP_REFERER']).hostname
                 if (not referring_domain) or (referring_domain not in settings.GLOBAL_LOGIN_ALLOW_EMBED_DOMAINS):
@@ -221,7 +218,7 @@ def embed_media(request):
                 raise PermissionDenied("HTTP referer not set.")
 
     except PermissionDenied:
-        return render(request,"cms/embed-403.html")
+        return render(request, "cms/embed-403.html")
         
     context = {}
     context["media"] = friendly_token

--- a/templates/cms/embed-403.html
+++ b/templates/cms/embed-403.html
@@ -1,0 +1,39 @@
+<body>
+<style>
+        .fakePlayer {
+                background-color: #242424;
+                position: absolute;
+                top: 0px;
+                left: 0px;
+                right: 0px;
+                bottom: 0px;
+                padding: 0px;
+                color: white;
+                width: auto;
+                height: auto;
+                text-align: center;
+        }
+        .center {
+                margin: 0;
+                position: absolute;
+                top: 50%;
+                left: 0px;
+                right: 0px;
+                -ms-transform: translate(0,-50%);
+                transform: translate(0,-50%);
+                text-align: center;
+        }
+</style>
+<div class="fakePlayer">
+        <div class="center">
+                <p> 403 - Forbidden </p>
+<p>
+<svg xmlns="http://www.w3.org/2000/svg" width="85" height="85" fill="currentColor" class="bi bi-x" viewBox="0 0 16 16">
+  <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708"/>
+</svg>
+</p>
+<p>Embedded media is not permitted from this referer.</p>
+<p> If this is a preview, please save your content to see the video.</p>
+        </div>
+</div>
+</body>

--- a/users/adapter.py
+++ b/users/adapter.py
@@ -10,10 +10,10 @@ class MyAccountAdapter(DefaultAccountAdapter):
         return settings.SSL_FRONTEND_HOST + url
 
     def clean_email(self, email):
-        if hasattr(settings,"ALLOWED_DOMAINS_FOR_USER_REGISTRATION") and settings.ALLOWED_DOMAINS_FOR_USER_REGISTRATION:
+        if hasattr(settings, "ALLOWED_DOMAINS_FOR_USER_REGISTRATION") and settings.ALLOWED_DOMAINS_FOR_USER_REGISTRATION:
             if email.split("@")[1] not in settings.ALLOWED_DOMAINS_FOR_USER_REGISTRATION:
                 raise ValidationError("Domain is not in the permitted list")
-            
+
         if email.split("@")[1] in settings.RESTRICTED_DOMAINS_FOR_USER_REGISTRATION:
             raise ValidationError("Domain is restricted from registering")
         return email


### PR DESCRIPTION
1). Add a settings key to optionally allow embedding videos from a list of trusted referers when GLOBAL_LOGIN_REQUIRED is true. This is useful if you wish to use MediaCMS as a back-end content manager, with the embedded files being used on another site.

2). If above option is set, modify the auth-bypass regex list in settings.py to permit loading from all origins in the embed view without auth, to paths in r'^/embed.\*' and r'^/media/.\*'

3). Modify embed view to validate embed requests against the list of allowed referers - check request.META['HTTP_REFERER'], parse the domain, and compare to the list. This required including urlparse to perform the domain parse in a reliable and standard way in this view.

4). Create a "fake player" to render (templates/cms/embed-403.html) with a mock 403 error, that fits to parent element and is generally styled like a generic player element. This is required since embedding in rich content editors often does not properly set referrer on otherwise trusted sites, and giving a 500 API error or redirecting to the MediaCMS main login page is not desirable in this use case.

Example "Bad referrer" render in the stock embed iframe:
<img width="579" alt="image" src="https://github.com/user-attachments/assets/2b154a7d-4c5d-43e4-8a58-f8d14ae9d358">

5). Doc updates to reflect this new option and its usage.
