### PR TITLE
Do not pin the micro-version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.4-bookworm AS compile-image
+FROM python:3.11-bookworm AS compile-image
 
 SHELL ["/bin/bash", "-c"]
 
@@ -25,7 +25,7 @@ RUN wget -q http://zebulon.bok.net/Bento4/binaries/Bento4-SDK-1-6-0-637.x86_64-u
     rm Bento4-SDK-1-6-0-637.x86_64-unknown-linux.zip
 
 ############ RUNTIME IMAGE ############
-FROM python:3.11.4-bookworm as runtime-image
+FROM python:3.11-bookworm
 
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
 - the mediacms Docker build needs to pick up security patches
 - this patch removes pinning the base system to 3.11.4, which otherwise probits security patches more recent than 3.11.4 from being picked up by a fresh container build
 - as of the time of this writing, the python-3.11 base has advanced to 3.11.11: see https://github.com/docker-library/python/blob/ded42cf/3.11/bullseye/Dockerfile
 - not declaring the micro version ensures the latest up-to-date base platform image is automatically used
 - in terms of risk we must consider that users are putting this platform on the DMX Internet. The security benefits clearly outweigh any possible (unlikely) minor regressions, since micro version updates are defined as not breaking API/ABI and since this semver based best-practice is closely adhered to in the upstream Linux developer communities.

## Description
<!-- Describe the changes introduced by this PR for the reviewers to fully understand. -->


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

