### PR TITLE
Nit: Fix Docker WARN: FromAsCasing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /home/mediacms.io/bento4 && \
     rm Bento4-SDK-1-6-0-637.x86_64-unknown-linux.zip
 
 ############ RUNTIME IMAGE ############
-FROM python:3.13-bookworm as runtime-image
+FROM python:3.13-bookworm AS runtime_image
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
    Fixes: L27 'as' and 'FROM' keywords' casing do not match

## Description
<!-- Describe the changes introduced by this PR for the reviewers to fully understand. -->


## Steps
<!-- Actions to be done pre and post deployment -->
*Pre-deploy*

*Post-deploy*

