### PR TITLE
More robust logging and outputs for all exceptions

### DIFF
--- a/files/backends.py
+++ b/files/backends.py
@@ -35,6 +35,7 @@ class FFmpegBackend(object):
                 close_fds=True,
             )
         except OSError as e:
+            logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
             raise VideoEncodingError("Error while running ffmpeg", e)
 
     def _check_returncode(self, process):
@@ -53,13 +54,16 @@ class FFmpegBackend(object):
                 break
             try:
                 out = out.decode(console_encoding)
-            except UnicodeDecodeError:
+            except UnicodeDecodeError as e:
+                logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
                 out = ""
             output = output[-500:] + out
             buf = buf[-500:] + out
             try:
                 line, buf = buf.split("\r", 1)
-            except BaseException:
+            except BaseException as e:
+                logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
+                logger.debug("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
                 continue
 
             progress = RE_TIMECODE.findall(line)

--- a/files/helpers.py
+++ b/files/helpers.py
@@ -1,6 +1,7 @@
 # Kudos to Werner Robitza, AVEQ GmbH, for helping with ffmpeg
 # related content
 
+import logging
 import hashlib
 import json
 import os
@@ -12,6 +13,8 @@ from fractions import Fraction
 
 import filetype
 from django.conf import settings
+
+logger = logging.getLogger(__name__)
 
 CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
@@ -162,7 +165,8 @@ def rm_dir(directory):
             try:
                 shutil.rmtree(directory)
                 return True
-            except (FileNotFoundError, PermissionError):
+            except (FileNotFoundError, PermissionError) as e:
+                logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
                 pass
     return False
 
@@ -217,16 +221,19 @@ def run_command(cmd, cwd=None):
     if process.returncode == 0:
         try:
             ret["out"] = stdout.decode("utf-8")
-        except BaseException:
+        except BaseException as e:
+            logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
             ret["out"] = ""
         try:
             ret["error"] = stderr.decode("utf-8")
-        except BaseException:
+        except BaseException as e:
+            logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
             ret["error"] = ""
     else:
         try:
             ret["error"] = stderr.decode("utf-8")
-        except BaseException:
+        except BaseException as e:
+            logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
             ret["error"] = ""
     return ret
 
@@ -291,7 +298,8 @@ def media_file_info(input_file):
     stdout = run_command(cmd).get("out")
     try:
         info = json.loads(stdout)
-    except TypeError:
+    except TypeError as e:
+        logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
         ret["fail"] = True
         return ret
 
@@ -327,7 +335,8 @@ def media_file_info(input_file):
         duration_str = video_info["tags"]["DURATION"]
         try:
             hms, msec = duration_str.split(".")
-        except ValueError:
+        except ValueError as e:
+            logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
             hms, msec = duration_str.split(",")
 
         total_dur = sum(int(x) * 60**i for i, x in enumerate(reversed(hms.split(":"))))
@@ -347,7 +356,8 @@ def media_file_info(input_file):
         format_info = json.loads(stdout)["format"]
         try:
             video_duration = float(format_info["duration"])
-        except KeyError:
+        except KeyError as e:
+            logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
             ret["fail"] = True
             return ret
 
@@ -407,7 +417,8 @@ def media_file_info(input_file):
             duration_str = audio_info["tags"]["DURATION"]
             try:
                 hms, msec = duration_str.split(".")
-            except ValueError:
+            except ValueError as e:
+                logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
                 hms, msec = duration_str.split(",")
             total_dur = sum(int(x) * 60**i for i, x in enumerate(reversed(hms.split(":"))))
             audio_duration = total_dur + float("0." + msec)
@@ -700,7 +711,8 @@ def get_base_ffmpeg_command(
 def produce_ffmpeg_commands(media_file, media_info, resolution, codec, output_filename, pass_file, chunk=False):
     try:
         media_info = json.loads(media_info)
-    except BaseException:
+    except BaseException as e:
+        logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
         media_info = {}
 
     if codec == "h264":

--- a/files/methods.py
+++ b/files/methods.py
@@ -94,7 +94,8 @@ def is_mediacms_editor(user):
     try:
         if user.is_superuser or user.is_manager or user.is_editor:
             editor = True
-    except BaseException:
+    except BaseException as e:
+        logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
         pass
     return editor
 
@@ -106,7 +107,8 @@ def is_mediacms_manager(user):
     try:
         if user.is_superuser or user.is_manager:
             manager = True
-    except BaseException:
+    except BaseException as e:
+        logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
         pass
     return manager
 
@@ -280,7 +282,8 @@ def show_related_media_content(media, request, limit):
 
     try:
         m.remove(media)  # remove media from results
-    except ValueError:
+    except ValueError as e:
+        logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
         pass
 
     random.shuffle(m)
@@ -301,7 +304,8 @@ def show_related_media_author(media, request, limit):
 
     try:
         m.remove(media)  # remove media from results
-    except ValueError:
+    except ValueError as e:
+        logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
         pass
 
     random.shuffle(m)

--- a/files/models.py
+++ b/files/models.py
@@ -418,8 +418,9 @@ class Media(models.Model):
         try:
             with connection.cursor() as cursor:
                 cursor.execute(sql_code)
-        except BaseException:
-            pass  # TODO:add log
+        except BaseException as e:
+            logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
+            pass
         return True
 
     def media_init(self):
@@ -463,7 +464,8 @@ class Media(models.Model):
             elif ret.get("is_video") or ret.get("is_audio"):
                 try:
                     self.media_info = json.dumps(ret)
-                except TypeError:
+                except TypeError as e:
+                    logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
                     self.media_info = ""
                 self.md5sum = ret.get("md5sum")
                 self.size = helpers.show_file_size(ret.get("file_size"))
@@ -1517,7 +1519,8 @@ def encoding_file_save(sender, instance, created, **kwargs):
         if instance.media_file:
             try:
                 orig_chunks = json.loads(instance.chunks_info).keys()
-            except BaseException:
+            except BaseException as e:
+                logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
                 instance.delete()
                 return False
 

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 import os
 import sys
+import logger
+
+logger = logging.getLogger(__name__)
 
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cms.settings")
@@ -8,6 +11,7 @@ if __name__ == "__main__":
 
     try:
         from django.core.management import execute_from_command_line
-    except ImportError as exc:
+    except ImportError as e:
+        logger.error("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
         raise ImportError("Couldn't import Django. Are you sure it's installed and " "available on your PYTHONPATH environment variable? Did you " "forget to activate a virtual environment?") from exc
     execute_from_command_line(sys.argv)

--- a/uploader/views.py
+++ b/uploader/views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import shutil
+import logging
 
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
@@ -14,6 +15,8 @@ from files.models import Media
 
 from .fineuploader import ChunkedFineUploader
 from .forms import FineUploaderUploadForm, FineUploaderUploadSuccessForm
+
+logger = logging.getLogger(__name__)
 
 
 class FineUploaderView(generic.FormView):
@@ -53,7 +56,8 @@ class FineUploaderView(generic.FormView):
         if self.upload.concurrent and self.chunks_done:
             try:
                 self.upload.combine_chunks()
-            except FileNotFoundError:
+            except FileNotFoundError as e:
+                logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
                 data = {"success": False, "error": "Error with File Uploading"}
                 return self.make_response(data, status=400)
         elif self.upload.total_parts == 1:

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.mail import EmailMessage
@@ -26,12 +28,15 @@ from .forms import ChannelForm, UserForm
 from .models import Channel, User
 from .serializers import LoginSerializer, UserDetailSerializer, UserSerializer
 
+logger = logging.getLogger(__name__)
+
 
 def get_user(username):
     try:
         user = User.objects.get(username=username)
         return user
-    except User.DoesNotExist:
+    except User.DoesNotExist as e:
+        logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
         return None
 
 
@@ -214,9 +219,11 @@ class UserDetail(APIView):
             # has_object_permission() after has_permission has succeeded
             self.check_object_permissions(self.request, user)
             return user
-        except PermissionDenied:
+        except PermissionDenied as e:
+            logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
             return Response({"detail": "not enough permissions"}, status=status.HTTP_400_BAD_REQUEST)
-        except User.DoesNotExist:
+        except User.DoesNotExist as e:
+            logger.warning("Caught exception: type=%s, message=%s", type(e).__name__, str(e))
             return Response({"detail": "user does not exist"}, status=status.HTTP_400_BAD_REQUEST)
 
     @swagger_auto_schema(


### PR DESCRIPTION
This is a change to ensure that logging is configured in a sane fashion.  I reworked the configuration so that it will honor LOGLEVEL except when DEBUG is enabled.  Arguments maybe on the best implementation, but I'm running in Kubernetes and want to see warnings+ only.

## Description
Found all exception catches, they now print warnings.  Could argue some might be better as debug/info.  Found missing `import logging` and added appropriate `logger =` setup.

## Steps
With `DEBUG=False`
1. Run MediaCMS, set `DEBUG=False` and `LOGLEVEL` to `[DEBUG|INFO|WARN|ERROR]`
2. Outputs ONLY to console, no files, `LOGLEVEL` and up.
2. Logs should properly be logged, filtered and things will be more obvious.

1. Run MediaCMS, set `DEBUG=True` and `LOGLEVEL` is ignored
2. Outputs to console AND error_files
3. Logs should be properly logged, filtered and things will be way more verbose
