### PR TITLE
Add Open ID Connect (OIDC) Login

### DIFF
--- a/cms/settings.py
+++ b/cms/settings.py
@@ -126,6 +126,23 @@ ACCOUNT_EMAIL_CONFIRMATION_EXPIRE_DAYS = 1
 # registration won't be open, might also consider to remove links for register
 USERS_CAN_SELF_REGISTER = True
 
+# Uncomment and fill relevant information in this for adding social login
+# keycloak is given as example, but any OIDC provider can be added including Google, Auth0 etc.
+
+# SOCIALACCOUNT_PROVIDERS = {
+#     "openid_connect": {
+#         "APP": {
+#             "provider_id": "keycloak",
+#             "name": "Keycloak",
+#             "client_id": "xxxxx",
+#             "secret": "xxxxxx",
+#             "settings": {
+#                 "server_url": "https://keycloak.xxxxxx.com/realms/xxxxxx/.well-known/openid-configuration",
+#             },
+#         }
+#     }
+# }
+
 RESTRICTED_DOMAINS_FOR_USER_REGISTRATION = ["xxx.com", "emaildomainwhatever.com"]
 
 # Comma separated list of domains:  ["organization.com", "private.organization.com", "org2.com"]
@@ -261,6 +278,7 @@ INSTALLED_APPS = [
     "allauth",
     "allauth.account",
     "allauth.socialaccount",
+    "allauth.socialaccount.providers.openid_connect",
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -3,6 +3,9 @@
 {% block headtitle %} | Sign In{% endblock headtitle %}
 
 {% block innercontent %}
+
+{% load socialaccount %}
+
 <div class="user-action-form-wrap">
     <div class="user-action-form-inner">
 
@@ -18,6 +21,17 @@
 		  {% endif %}
 		  <button class="primaryAction" type="submit">Sign In</button>
 		</form>
+
+		{% get_providers as socialaccount_providers %}
+		{% if socialaccount_providers %}
+			<h1 style="margin-top: 5%;">Sign In with Social Accounts</h1>
+			{% for provider in socialaccount_providers %}
+				<form class="login" method="POST" action="{% provider_login_url provider %}">
+					{% csrf_token %}
+					<button class="primaryAction" type="submit">Sign In with {{provider}}</button>
+				</form>
+			{% endfor %}
+		{% endif %}
 
     </div>
 </div>


### PR DESCRIPTION
Added OpenID connect login system. I chose OIDC as the provider because it's generic enough and supported by most SSO providers like keycloak, auth0, google etc.

I could get this working only with v4.6 because 5.0 introduced SAML, RBAC etc and complicated things.  
