### PR TITLE
Fixing date picker in edit media

### DIFF
--- a/files/forms.py
+++ b/files/forms.py
@@ -34,7 +34,7 @@ class MediaMetadataForm(forms.ModelForm):
         widgets = {
             "new_tags": MultipleSelect(),
             "description": forms.Textarea(attrs={'rows': 4}),
-            "add_date": forms.DateInput(attrs={'type': 'date'}),
+            "add_date": forms.DateInput(attrs={'type': 'date'}, format='%Y-%m-%d'),
             "thumbnail_time": forms.NumberInput(attrs={'min': 0, 'step': 0.1}),
         }
         labels = {


### PR DESCRIPTION
By default, Django uses type=text for the date input, which respects the locale settings. However, when changing the input type to date, it should only accept YYYY-MM-DD format so the input field can be properly handled.

Before:
<img width="710" alt="截圖 2025-06-16 上午11 11 48" src="https://github.com/user-attachments/assets/fe907ef1-b360-4dd6-b86a-13664ebaee96" />

After:
<img width="710" alt="截圖 2025-06-16 上午11 12 11" src="https://github.com/user-attachments/assets/7ca308f1-09eb-4633-916e-10e9aef5f420" />





