### PR TITLE
Updated the title splicing length to 100 in playlist, category and media models

### DIFF
--- a/files/models/category.py
+++ b/files/models/category.py
@@ -138,7 +138,7 @@ class Tag(models.Model):
 
     def save(self, *args, **kwargs):
         self.title = helpers.get_alphanumeric_only(self.title)
-        self.title = self.title[:99]
+        self.title = self.title[:100]
         super(Tag, self).save(*args, **kwargs)
 
     @property

--- a/files/models/media.py
+++ b/files/models/media.py
@@ -243,7 +243,7 @@ class Media(models.Model):
         strip_text_items = ["title", "description"]
         for item in strip_text_items:
             setattr(self, item, strip_tags(getattr(self, item, None)))
-        self.title = self.title[:99]
+        self.title = self.title[:100]
 
         # if thumbnail_time specified, keep up to single digit
         if self.thumbnail_time:

--- a/files/models/playlist.py
+++ b/files/models/playlist.py
@@ -64,7 +64,7 @@ class Playlist(models.Model):
         strip_text_items = ["title", "description"]
         for item in strip_text_items:
             setattr(self, item, strip_tags(getattr(self, item, None)))
-        self.title = self.title[:99]
+        self.title = self.title[:100]
 
         if not self.friendly_token:
             while True:


### PR DESCRIPTION
## Description
The title was being spliced as title[:99] which fixed it's length to 99 characters, so I updated it to [:100] in the playlists, categories and media models.

#1339 



