### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+Thank you for helping improve the security of MediaCMS.
+We take security vulnerabilities seriously and appreciate responsible disclosure.
+
+---
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in MediaCMS, **please do not open a public GitHub issue**.
+
+Instead, report it using one of the following methods:
+
+- **GitHub Security Advisories (preferred)**  
+  Use the "Report a vulnerability" feature in this repository.
+
+- **Contact Form**  
+  Submit details via the official contact page:  
+  https://mediacms.io/contact/
+
+Please include as much of the following information as possible:
+- Affected version(s)
+- Detailed description of the issue
+- Steps to reproduce (PoC if available)
+- Impact assessment (e.g. RCE, XSS, privilege escalation)
+- Any potential mitigations you are aware of
+
+---
+
+## Supported Versions
+
+Security updates are provided for the **latest stable release** of MediaCMS.
+Older versions may not receive security patches.
+
+---
+
+## Disclosure Policy
+
+- We aim to acknowledge reports within **7 days**
+- We aim to provide a fix or mitigation within **90 days**, depending on severity
+- Please allow us time to investigate before any public disclosure
+
+We follow responsible disclosure practices and will coordinate disclosure timelines when appropriate.
+
+---
+
+## Recognition
+
+At this time, MediaCMS does not operate a formal bug bounty program.
+However, we are happy to acknowledge valid security reports in release notes or advisories (with your permission).
+
+---
+
+Thank you for helping keep MediaCMS secure.


### PR DESCRIPTION
### Summary
This PR adds a SECURITY.md file to clarify the responsible vulnerability
disclosure process for MediaCMS and to enable GitHub Security Advisories.

### Background
While reviewing MediaCMS, I identified a security issue that should be
reported privately rather than through a public GitHub issue.

At the moment, there is no documented security reporting process, which
makes it difficult to report vulnerabilities in a responsible way.

### Why this change
Adding SECURITY.md allows:
- Enabling GitHub's built-in "Report a vulnerability" feature
- Preventing accidental public disclosure via Issues
- Providing a clear and standard disclosure path for security researchers

### Next steps
Once this PR is merged, I plan to report the identified issue via
GitHub Security Advisories or the official contact form, following the
defined disclosure process.

Thanks for maintaining MediaCMS, and I appreciate your consideration.