### PR TITLE
fix: prestart.sh loaddata re-runs on every container restart

### DIFF
--- a/deploy/docker/prestart.sh
+++ b/deploy/docker/prestart.sh
@@ -6,7 +6,7 @@ ADMIN_PASSWORD=${ADMIN_PASSWORD:-$RANDOM_ADMIN_PASS}
 if [ X"$ENABLE_MIGRATIONS" = X"yes" ]; then
     echo "Running migrations service"
     python manage.py migrate
-    EXISTING_INSTALLATION=`echo "from users.models import User; print(User.objects.exists())" |python manage.py shell`
+    EXISTING_INSTALLATION=`echo "from users.models import User; print(User.objects.exists())" |python manage.py shell 2>/dev/null | tail -1`
     if [ "$EXISTING_INSTALLATION" = "True" ]; then
         echo "Loaddata has already run"
     else


### PR DESCRIPTION
## Problem

When deploying with Docker, `fixtures/categories.json` and other loaddata fixtures are re-imported on **every container restart**, even on existing installations. This causes deleted sample data (e.g. default categories) to reappear after each restart.

## Root Cause

`prestart.sh` detects existing installations with an exact string comparison:
```bash
EXISTING_INSTALLATION=`echo "from users.models import User; print(User.objects.exists())" |python manage.py shell`
if [ "$EXISTING_INSTALLATION" = "True" ]; then
```

When `manage.py shell` runs in non-interactive (pipe) mode, it outputs extra lines to **stdout** before the actual result:
```
44 objects imported automatically (use -v 2 for details).
True
```

So `$EXISTING_INSTALLATION` contains two lines and is never equal to `"True"` — the condition always fails, and the script treats every restart as a fresh installation.

Reproduced with:
```bash
docker compose exec web \
  bash -c 'echo "from users.models import User; print(User.objects.exists())" | python manage.py shell'
```

Output:
```
44 objects imported automatically (use -v 2 for details).
True
```

## Fix

Redirect stderr to `/dev/null` and pipe through `tail -1` to extract only the last line, leaving the original `= "True"` comparison intact:
```bash
EXISTING_INSTALLATION=`echo "from users.models import User; print(User.objects.exists())" |python manage.py shell 2>/dev/null | tail -1`
if [ "$EXISTING_INSTALLATION" = "True" ]; then
```

Minimal change — only `2>/dev/null | tail -1` is added. No logic is altered.

## Testing

1. Deploy with docker-compose
2. Delete the default categories from the admin panel
3. Restart containers — sample categories no longer reappear ✓
4. Fresh install still works correctly — loaddata runs as expected ✓