### PR TITLE
fix: SAML provider add guard to skip empty mappings before iterating

### DIFF
--- a/cms/version.py
+++ b/cms/version.py
@@ -1,1 +1,1 @@
-VERSION = "8.2.0"
+VERSION = "8.2.1"

--- a/saml_auth/adapter.py
+++ b/saml_auth/adapter.py
@@ -73,7 +73,7 @@ def perform_user_actions(user, social_account, common_fields=None):
     if social_app:
         saml_configuration = social_app.saml_configurations.first()
 
-    add_user_logo(user, extra_data)
+    add_user_logo(user, extra_data, saml_configuration)
     handle_role_mapping(user, extra_data, social_app, saml_configuration)
     if saml_configuration and saml_configuration.save_saml_response_logs:
         handle_saml_logs_save(user, extra_data, social_app)
@@ -81,10 +81,13 @@ def perform_user_actions(user, social_account, common_fields=None):
     return user
 
 
-def add_user_logo(user, extra_data):
+def add_user_logo(user, extra_data, saml_configuration=None):
+    # use the attribute name configured in the SAML Configuration, falling
+    # back to "jpegPhoto" when it is left empty
+    logo_key = (saml_configuration.user_logo if saml_configuration and saml_configuration.user_logo else None) or "jpegPhoto"
     try:
-        if extra_data.get("jpegPhoto") and user.logo.name in ["userlogos/user.jpg", "", None]:
-            base64_string = extra_data.get("jpegPhoto")[0]
+        if extra_data.get(logo_key) and user.logo.name in ["userlogos/user.jpg", "", None]:
+            base64_string = extra_data.get(logo_key)[0]
             image_data = base64.b64decode(base64_string)
             image_content = ContentFile(image_data)
             user.logo.save('user.jpg', image_content, save=True)

--- a/saml_auth/custom/provider.py
+++ b/saml_auth/custom/provider.py
@@ -18,6 +18,15 @@ class CustomSAMLProvider(SAMLProvider):
             provider_config = self.app.settings
 
         raw_attributes = data.get_attributes()
+        # get_attributes() keys attributes by their full Name. Some IdPs send
+        # certain attributes only under their FriendlyName, so fall back to the
+        # FriendlyName-keyed attributes when a Name lookup misses. The Name
+        # lookup is always preferred, so attributes that already resolve are
+        # unaffected.
+        try:
+            friendly_attributes = data.get_friendlyname_attributes()
+        except AttributeError:
+            friendly_attributes = {}
         attributes = {}
         attribute_mapping = provider_config.get("attribute_mapping", self.default_attribute_mapping)
         # map configured provider attributes
@@ -28,7 +37,9 @@ class CustomSAMLProvider(SAMLProvider):
             if isinstance(provider_keys, str):
                 provider_keys = [provider_keys]
             for provider_key in provider_keys:
-                attribute_list = raw_attributes.get(provider_key, None)
+                attribute_list = raw_attributes.get(provider_key)
+                if attribute_list is None:
+                    attribute_list = friendly_attributes.get(provider_key)
                 # if more than one keys, get them all comma separated
                 if attribute_list is not None and len(attribute_list) > 1:
                     attributes[key] = ",".join(attribute_list)

--- a/saml_auth/custom/provider.py
+++ b/saml_auth/custom/provider.py
@@ -22,6 +22,9 @@ class CustomSAMLProvider(SAMLProvider):
         attribute_mapping = provider_config.get("attribute_mapping", self.default_attribute_mapping)
         # map configured provider attributes
         for key, provider_keys in attribute_mapping.items():
+            # skip mappings left empty/None in the SAML Configuration
+            if not provider_keys:
+                continue
             if isinstance(provider_keys, str):
                 provider_keys = [provider_keys]
             for provider_key in provider_keys:


### PR DESCRIPTION
## Description
small SAML related optimizations

1. add guard to skip empty mappings before iterating
2. get user_logo from admin config, instead of hard coded value jpegPhoto
3. check the uid field through Shibboleth's FriendlyName (in case it doesn't find it in Name)
	