### PR TITLE
fix: return 404 for unknown pages and append missing trailing slash

### DIFF
--- a/files/views/pages.py
+++ b/files/views/pages.py
@@ -6,8 +6,9 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.mail import EmailMessage
-from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
+from django.http import HttpResponse, HttpResponsePermanentRedirect, HttpResponseRedirect, JsonResponse
 from django.shortcuts import render
+from django.urls import is_valid_path
 from django.utils.html import mark_safe, strip_tags
 from django.views.decorators.csrf import csrf_exempt
 
@@ -45,7 +46,16 @@ def get_page(request, slug):
     if page:
         context["page"] = page
     else:
-        return render(request, "404.html", context)
+        # This view is the catch-all for any single segment path, so it also
+        # matches near misses like /admin or /swagger. Because the path then
+        # resolves, CommonMiddleware never appends the trailing slash that
+        # would reach the real view, so do it here instead.
+        slashed = f"{request.path_info}/"
+        if not request.path_info.endswith("/") and is_valid_path(slashed):
+            return HttpResponsePermanentRedirect(slashed)
+        # Otherwise carry a real 404 status: returning 200 here would mask
+        # every unknown URL as a valid page.
+        return render(request, "404.html", context, status=404)
     return render(request, "cms/page.html", context)
 
 


### PR DESCRIPTION
In the web GUI /admin and /swagger currently go nowhere. 
They render an error page with HTTP 200, and Django never redirects them to the working /admin/ and /swagger/
Only when deliberately adding a trailing / to the url, these pages are accessable.

What

In files/views/pages.py, the get_page catch-all now:

- returns status=404 when no Page matches, instead of a 200 carrying 404.html
- redirects to the slashed path first, when that path resolves.

Why

files/urls.py routes ^(?P<slug>[\w.-]*)$ to get_page, so this view receives every single segment path, including near misses like /admin and /swagger

Returning 200 had two consequences. 
Every unknown URL reported success, hiding broken links from crawlers, monitoring and tests. 
CommonMiddleware.process_response only appends a trailing slash when the response is a 404 and the unslashed path does not resolve, so APPEND_SLASH could never fire here 
The catch-all made /admin resolve. 
Fixing the status alone is therefore not enough, so the view restores the slash behaviour the catch-all displaces, using the same HttpResponsePermanentRedirect class Django's own middleware uses.


